### PR TITLE
feat(compiler): notify on toggle watch start and stop

### DIFF
--- a/lua/preview/commands.lua
+++ b/lua/preview/commands.lua
@@ -27,9 +27,9 @@ local function dispatch(args)
     if s.watching then
       table.insert(parts, 'watching')
     end
-    vim.notify('[preview.nvim] ' .. table.concat(parts, ', '), vim.log.levels.INFO)
+    vim.notify('[preview.nvim]: ' .. table.concat(parts, ', '), vim.log.levels.INFO)
   else
-    vim.notify('[preview.nvim] unknown subcommand: ' .. subcmd, vim.log.levels.ERROR)
+    vim.notify('[preview.nvim]: unknown subcommand: ' .. subcmd, vim.log.levels.ERROR)
   end
 end
 

--- a/lua/preview/compiler.lua
+++ b/lua/preview/compiler.lua
@@ -178,6 +178,7 @@ end
 function M.toggle(bufnr, name, provider, ctx_builder)
   if watching[bufnr] then
     M.unwatch(bufnr)
+    vim.notify('[preview.nvim]: watching stopped', vim.log.levels.INFO)
     return
   end
 
@@ -202,6 +203,7 @@ function M.toggle(bufnr, name, provider, ctx_builder)
 
   watching[bufnr] = au_id
   log.dbg('watching buffer %d with provider "%s"', bufnr, name)
+  vim.notify('[preview.nvim]: watching with "' .. name .. '"', vim.log.levels.INFO)
 
   vim.api.nvim_create_autocmd('BufWipeout', {
     buffer = bufnr,


### PR DESCRIPTION
## Problem

`:Preview toggle` gave no user feedback, leaving the user to guess whether watching was enabled or disabled after invoking the command.

## Solution

Emit `vim.notify` on both edges of the toggle: `[preview.nvim]: watching with "<provider>"` when watch starts, `[preview.nvim]: watching stopped` when it stops. Notifications only fire from `M.toggle`, so `unwatch` calls triggered by `BufWipeout` remain silent. Also normalises the `[preview.nvim]:` prefix in `commands.lua` to use a colon consistently.