### PR TITLE
refactor(compiler): resolve output before args

### DIFF
--- a/lua/preview/compiler.lua
+++ b/lua/preview/compiler.lua
@@ -53,19 +53,21 @@ function M.compile(bufnr, name, provider, ctx)
     M.stop(bufnr)
   end
 
+  local output_file = ''
+  if provider.output then
+    output_file = eval_string(provider.output, ctx)
+  end
+
+  local resolved_ctx = vim.tbl_extend('force', ctx, { output = output_file })
+
   local cmd = vim.list_extend({}, provider.cmd)
   if provider.args then
-    vim.list_extend(cmd, eval_list(provider.args, ctx))
+    vim.list_extend(cmd, eval_list(provider.args, resolved_ctx))
   end
 
   local cwd = ctx.root
   if provider.cwd then
-    cwd = eval_string(provider.cwd, ctx)
-  end
-
-  local output_file = ''
-  if provider.output then
-    output_file = eval_string(provider.output, ctx)
+    cwd = eval_string(provider.cwd, resolved_ctx)
   end
 
   if output_file ~= '' then

--- a/lua/preview/init.lua
+++ b/lua/preview/init.lua
@@ -19,6 +19,7 @@
 ---@field file string
 ---@field root string
 ---@field ft string
+---@field output? string
 
 ---@class preview.Diagnostic
 ---@field lnum integer

--- a/lua/preview/presets.lua
+++ b/lua/preview/presets.lua
@@ -138,8 +138,7 @@ M.markdown = {
   ft = 'markdown',
   cmd = { 'pandoc' },
   args = function(ctx)
-    local output = ctx.file:gsub('%.md$', '.html')
-    return { ctx.file, '-s', '--embed-resources', '-o', output }
+    return { ctx.file, '-s', '--embed-resources', '-o', ctx.output }
   end,
   output = function(ctx)
     return (ctx.file:gsub('%.md$', '.html'))
@@ -158,7 +157,6 @@ M.github = {
   ft = 'markdown',
   cmd = { 'pandoc' },
   args = function(ctx)
-    local output = ctx.file:gsub('%.md$', '.html')
     return {
       '-f',
       'gfm',
@@ -168,7 +166,7 @@ M.github = {
       '--css',
       'https://cdn.jsdelivr.net/gh/pixelbrackets/gfm-stylesheet@master/dist/gfm.css',
       '-o',
-      output,
+      ctx.output,
     }
   end,
   output = function(ctx)

--- a/spec/presets_spec.lua
+++ b/spec/presets_spec.lua
@@ -150,6 +150,7 @@ describe('presets', function()
       file = '/tmp/document.md',
       root = '/tmp',
       ft = 'markdown',
+      output = '/tmp/document.html',
     }
 
     it('has ft', function()
@@ -233,6 +234,7 @@ describe('presets', function()
       file = '/tmp/document.md',
       root = '/tmp',
       ft = 'markdown',
+      output = '/tmp/document.html',
     }
 
     it('has ft', function()


### PR DESCRIPTION
## Problem

Presets that need the output path in their `args` function (markdown, github) had to recompute it inline with a duplicate `gsub` expression already present in the `output` field. The two could drift independently.

## Solution

Resolve `output_file` first in `M.compile`, then extend ctx into a `resolved_ctx` (without mutating the original) before evaluating `args` and `cwd`. Preset `args` functions can now reference `ctx.output` directly. Add `output?` to the `preview.Context` type annotation.