### PR TITLE
fix(reload): bind SSE server to port 0 for OS-assigned port

### DIFF
--- a/lua/preview/reload.lua
+++ b/lua/preview/reload.lua
@@ -2,6 +2,7 @@ local M = {}
 
 local PORT = 5554
 local server_handle = nil
+local actual_port = nil
 local clients = {}
 
 local function make_script(port)
@@ -14,12 +15,15 @@ local function make_script(port)
 end
 
 function M.start(port)
-  port = port or PORT
   if server_handle then
     return
   end
   local server = vim.uv.new_tcp()
-  server:bind('127.0.0.1', port)
+  server:bind('127.0.0.1', port or 0)
+  local sockname = server:getsockname()
+  if sockname then
+    actual_port = sockname.port
+  end
   server:listen(128, function(err)
     if err then
       return
@@ -66,6 +70,7 @@ function M.stop()
     server_handle:close()
     server_handle = nil
   end
+  actual_port = nil
 end
 
 function M.broadcast()
@@ -85,7 +90,7 @@ function M.broadcast()
 end
 
 function M.inject(path, port)
-  port = port or PORT
+  port = actual_port or port or PORT
   local f = io.open(path, 'r')
   if not f then
     return


### PR DESCRIPTION
## Problem

The SSE reload server hardcoded port 5554 and never checked whether `server:bind()` succeeded. When that port was already in use, `listen()` would silently error and drop via `if err then return end`, but `inject()` still wrote the dead EventSource URL into the HTML. The browser would connect to whatever was on 5554 — or nothing — and live reload would silently stop working with no indication of why.

## Solution

Bind to `port or 0` so the OS assigns a free ephemeral port. After binding, call `server:getsockname()` to retrieve the actual assigned port and store it in `actual_port`. `inject()` now reads `actual_port` for the EventSource URL instead of the hardcoded constant, and `stop()` resets it. The `PORT = 5554` constant is kept only as a last-resort fallback in `inject()` if `actual_port` is somehow unset.