### PR TITLE
fix(compiler): check output exists before opening from long-running process

### DIFF
--- a/lua/preview/compiler.lua
+++ b/lua/preview/compiler.lua
@@ -147,7 +147,12 @@ function M.compile(bufnr, name, provider, ctx)
       end)
     )
 
-    if provider.open and not opened[bufnr] and output_file ~= '' and vim.uv.fs_stat(output_file) then
+    if
+      provider.open
+      and not opened[bufnr]
+      and output_file ~= ''
+      and vim.uv.fs_stat(output_file)
+    then
       if provider.open == true then
         vim.ui.open(output_file)
       elseif type(provider.open) == 'table' then


### PR DESCRIPTION
## Problem

For long-running processes (`reload = function/table`, e.g. `typst watch`), `M.compile()` calls the configured opener immediately after `vim.system()` — before the process has produced any output. On first run the output file does not yet exist, so the opener receives a nonexistent path.

## Solution

Wrap the open block with a `vim.uv.fs_stat` existence check. If the output file is already present from a previous run, it opens immediately as before. If not (first ever compile), opening is skipped; the user can invoke `:Preview open` once the process has produced output.