### PR TITLE
fix(ci): pass --configpath to lua-language-server

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -6,5 +6,5 @@ git ls-files '*.lua' | xargs nix develop --command selene --display-style quiet
 nix develop --command prettier --check .
 nix fmt
 git diff --exit-code -- '*.nix'
-nix develop --command lua-language-server --check lua/ --checklevel=Warning
+nix develop --command lua-language-server --check lua/ --configpath .luarc.json --checklevel=Warning
 nix develop --command busted


### PR DESCRIPTION
## Problem

\`lua-language-server --check lua/\` treats \`lua/\` as the workspace root and looks for \`.luarc.json\` there. It doesn't find it, so \`diagnostics.globals\` is never loaded and every \`vim.*\` reference is flagged as \`undefined-global\`. The GitHub CI action passes \`--configpath\` explicitly which is why it works in CI but not locally via \`scripts/ci.sh\`.

## Solution

Add \`--configpath .luarc.json\` to the lua-language-server invocation in \`scripts/ci.sh\`, matching what the CI action already does.