### PR TITLE
fix(ci): use absolute path for lua-language-server --configpath

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -6,5 +6,5 @@ git ls-files '*.lua' | xargs nix develop --command selene --display-style quiet
 nix develop --command prettier --check .
 nix fmt
 git diff --exit-code -- '*.nix'
-nix develop --command lua-language-server --check lua/ --configpath .luarc.json --checklevel=Warning
+nix develop --command lua-language-server --check lua/ --configpath "$(pwd)/.luarc.json" --checklevel=Warning
 nix develop --command busted


### PR DESCRIPTION
## Problem

\`--configpath\` is resolved relative to the workspace root passed to \`--check\` (i.e. \`lua/\`), not the current working directory. So \`--configpath .luarc.json\` was looking for \`lua/.luarc.json\`, not finding it, and leaving \`vim\` and \`jit\` as undefined globals across the entire \`lua/\` directory. The GitHub CI action works because it already passes an absolute path.

## Solution

Expand to an absolute path with \`\$(pwd)\` at shell invocation time, making the behaviour identical to what CI does.