### PR TITLE
fix(presets): asciidoctor failure-level, clean for all presets, no auto-open on compile

### DIFF
--- a/lua/preview/compiler.lua
+++ b/lua/preview/compiler.lua
@@ -162,6 +162,7 @@ function M.compile(bufnr, name, provider, ctx, opts)
 
     if
       provider.open
+      and not opts.oneshot
       and not opened[bufnr]
       and output_file ~= ''
       and vim.uv.fs_stat(output_file)
@@ -240,6 +241,7 @@ function M.compile(bufnr, name, provider, ctx, opts)
         end
         if
           provider.open
+          and not opts.oneshot
           and not opened[bufnr]
           and output_file ~= ''
           and vim.uv.fs_stat(output_file)

--- a/lua/preview/presets.lua
+++ b/lua/preview/presets.lua
@@ -128,6 +128,9 @@ M.typst = {
   error_parser = function(output)
     return parse_typst(output)
   end,
+  clean = function(ctx)
+    return { 'rm', '-f', (ctx.file:gsub('%.typ$', '.pdf')) }
+  end,
   open = true,
   reload = function(ctx)
     return { 'typst', 'watch', ctx.file }
@@ -172,6 +175,10 @@ M.pdflatex = {
   error_parser = function(output)
     return parse_latexmk(output)
   end,
+  clean = function(ctx)
+    local base = ctx.file:gsub('%.tex$', '')
+    return { 'rm', '-f', base .. '.pdf', base .. '.aux', base .. '.log', base .. '.synctex.gz' }
+  end,
   open = true,
 }
 
@@ -187,6 +194,9 @@ M.tectonic = {
   end,
   error_parser = function(output)
     return parse_latexmk(output)
+  end,
+  clean = function(ctx)
+    return { 'rm', '-f', (ctx.file:gsub('%.tex$', '.pdf')) }
   end,
   open = true,
 }
@@ -246,7 +256,7 @@ M.asciidoctor = {
   ft = 'asciidoc',
   cmd = { 'asciidoctor' },
   args = function(ctx)
-    return { ctx.file, '-o', ctx.output }
+    return { '--failure-level', 'ERROR', ctx.file, '-o', ctx.output }
   end,
   output = function(ctx)
     return (ctx.file:gsub('%.adoc$', '.html'))

--- a/spec/presets_spec.lua
+++ b/spec/presets_spec.lua
@@ -33,6 +33,10 @@ describe('presets', function()
       assert.are.equal('/tmp/document.pdf', output)
     end)
 
+    it('returns clean command', function()
+      assert.are.same({ 'rm', '-f', '/tmp/document.pdf' }, presets.typst.clean(ctx))
+    end)
+
     it('has open enabled', function()
       assert.is_true(presets.typst.open)
     end)
@@ -189,8 +193,16 @@ describe('presets', function()
       assert.is_true(presets.pdflatex.open)
     end)
 
-    it('has no clean command', function()
-      assert.is_nil(presets.pdflatex.clean)
+    it('returns clean command removing pdf and aux files', function()
+      local clean = presets.pdflatex.clean(tex_ctx)
+      assert.are.same({
+        'rm',
+        '-f',
+        '/tmp/document.pdf',
+        '/tmp/document.aux',
+        '/tmp/document.log',
+        '/tmp/document.synctex.gz',
+      }, clean)
     end)
 
     it('has no reload', function()
@@ -240,8 +252,8 @@ describe('presets', function()
       assert.is_true(presets.tectonic.open)
     end)
 
-    it('has no clean command', function()
-      assert.is_nil(presets.tectonic.clean)
+    it('returns clean command removing pdf', function()
+      assert.are.same({ 'rm', '-f', '/tmp/document.pdf' }, presets.tectonic.clean(tex_ctx))
     end)
 
     it('has no reload', function()
@@ -467,7 +479,7 @@ describe('presets', function()
 
     it('returns args with file and output', function()
       assert.are.same(
-        { '/tmp/document.adoc', '-o', '/tmp/document.html' },
+        { '--failure-level', 'ERROR', '/tmp/document.adoc', '-o', '/tmp/document.html' },
         presets.asciidoctor.args(adoc_ctx)
       )
     end)


### PR DESCRIPTION
## Problem

Three issues found during manual testing in the nix dev shell:

1. Asciidoctor exits 0 even on ERROR-level messages (e.g. unresolved includes), so \`error_parser\` never runs and errors are silently embedded as text in the HTML output.
2. \`typst\`, \`pdflatex\`, and \`tectonic\` had no \`clean\` command, so \`:Preview clean\` did nothing for those presets.
3. \`open = true\` fired on \`:Preview compile\` (one-shot), opening the viewer unexpectedly. Auto-open should only happen when starting a watch session via \`:Preview toggle\`.

## Solution

Pass \`--failure-level ERROR\` in the asciidoctor preset args so errors produce a non-zero exit and trigger \`error_parser\`. Add \`clean\` to \`typst\` (removes \`.pdf\`), \`pdflatex\` (removes \`.pdf\`, \`.aux\`, \`.log\`, \`.synctex.gz\`), and \`tectonic\` (removes \`.pdf\`). Gate auto-open on \`not opts.oneshot\` in both compile paths so it only fires during toggle/watch mode.