### PR TITLE
feat: add `detach` provider field and `vim.g.preview` config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,18 @@ Typst, Markdown, etc.)&mdash;diagnostics included.
 
 ## Installation
 
-Install with your package manager of choice or via
-[luarocks](https://luarocks.org/modules/barrettruth/preview.nvim):
+With lazy.nvim:
+
+```lua
+{
+  'barrettruth/preview.nvim',
+  init = function()
+    vim.g.preview = { typst = true, latex = true }
+  end,
+}
+```
+
+Or via [luarocks](https://luarocks.org/modules/barrettruth/preview.nvim):
 
 ```
 luarocks install preview.nvim

--- a/doc/preview.nvim.txt
+++ b/doc/preview.nvim.txt
@@ -23,12 +23,17 @@ REQUIREMENTS                                          *preview.nvim-requirements
 ==============================================================================
 SETUP                                                  *preview.nvim-setup*
 
-Load preview.nvim with your package manager. For example, with lazy.nvim: >lua
+With lazy.nvim, set |vim.g.preview| in `init` so configuration is applied
+before the plugin loads: >lua
     {
       'barrettruth/preview.nvim',
+      init = function()
+        vim.g.preview = { typst = true, latex = true }
+      end,
     }
 <
-Call |preview.setup()| to configure providers before use.
+Alternatively, call |preview.setup()| directly in a `config` function or
+anywhere the plugin is already loaded.
 
 ==============================================================================
 CONFIGURATION                                      *preview.nvim-configuration*
@@ -107,6 +112,12 @@ Provider fields:~
                                        command. If a function, receives a
                                        |preview.Context| and returns a
                                        string[].
+
+  `detach`           boolean           When `true`, the viewer process opened
+                                       via a string[] `open` command is not
+                                       sent SIGTERM when the buffer is deleted.
+                                       Has no effect when `open` is `true`.
+                                       Default: `false`.
 
                                                         *preview.Context*
 Context fields:~

--- a/lua/preview/compiler.lua
+++ b/lua/preview/compiler.lua
@@ -291,7 +291,9 @@ function M.compile(bufnr, name, provider, ctx, opts)
       callback = function()
         M.stop(bufnr)
         stop_open_watcher(bufnr)
-        close_viewer(bufnr)
+        if not provider.detach then
+          close_viewer(bufnr)
+        end
         last_output[bufnr] = nil
       end,
     })
@@ -404,7 +406,9 @@ function M.compile(bufnr, name, provider, ctx, opts)
     once = true,
     callback = function()
       M.stop(bufnr)
-      close_viewer(bufnr)
+      if not provider.detach then
+        close_viewer(bufnr)
+      end
       last_output[bufnr] = nil
     end,
   })
@@ -507,7 +511,9 @@ function M.toggle(bufnr, name, provider, ctx_builder)
     callback = function()
       M.unwatch(bufnr)
       stop_open_watcher(bufnr)
-      close_viewer(bufnr)
+      if not provider.detach then
+        close_viewer(bufnr)
+      end
       opened[bufnr] = nil
     end,
   })

--- a/lua/preview/init.lua
+++ b/lua/preview/init.lua
@@ -10,6 +10,7 @@
 ---@field clean? string[]|fun(ctx: preview.Context): string[]
 ---@field open? boolean|string[]
 ---@field reload? boolean|string[]|fun(ctx: preview.Context): string[]
+---@field detach? boolean
 
 ---@class preview.Config
 ---@field debug boolean|string
@@ -101,6 +102,7 @@ function M.setup(opts)
     end, 'false, "diagnostic", or "quickfix"')
     vim.validate(prefix .. '.open', provider.open, { 'boolean', 'table' }, true)
     vim.validate(prefix .. '.reload', provider.reload, { 'boolean', 'table', 'function' }, true)
+    vim.validate(prefix .. '.detach', provider.detach, 'boolean', true)
   end
 
   config = vim.tbl_deep_extend('force', default_config, {
@@ -245,5 +247,9 @@ M._test = {
     config = vim.deepcopy(default_config)
   end,
 }
+
+if vim.g.preview then
+  M.setup(vim.g.preview)
+end
 
 return M


### PR DESCRIPTION
## Problem

Viewer processes launched via a string[] `open` command were always
killed on buffer deletion with no opt-out. There was also no way to
configure the plugin before it loaded, requiring `setup()` in a
`config` hook.

## Solution

Add a `detach` boolean to `ProviderConfig` that skips SIGTERM on
buffer unload. Read `vim.g.preview` at module load time as an
alternative to `setup()`, enabling config via `init` hooks in
lazy-loaders like `lz.n`.