### PR TITLE
feat: add plantuml preset

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,7 @@
             pkgs.stylua
             pkgs.selene
             pkgs.lua-language-server
+            pkgs.plantuml
           ];
         };
       });

--- a/lua/preview/init.lua
+++ b/lua/preview/init.lua
@@ -105,6 +105,12 @@ function M.setup(opts)
     vim.validate(prefix .. '.detach', provider.detach, 'boolean', true)
   end
 
+  if providers['plantuml'] then
+    vim.filetype.add({
+      extension = { puml = 'plantuml', pu = 'plantuml' },
+    })
+  end
+
   config = vim.tbl_deep_extend('force', default_config, {
     debug = debug,
     providers = providers,

--- a/lua/preview/presets.lua
+++ b/lua/preview/presets.lua
@@ -272,6 +272,37 @@ M.asciidoctor = {
 }
 
 ---@type preview.ProviderConfig
+M.plantuml = {
+  ft = 'plantuml',
+  cmd = { 'plantuml' },
+  args = function(ctx)
+    return { '-tsvg', ctx.file }
+  end,
+  output = function(ctx)
+    return (ctx.file:gsub('%.puml$', '.svg'))
+  end,
+  error_parser = function(output)
+    local diagnostics = {}
+    for line in output:gmatch('[^\r\n]+') do
+      local lnum = line:match('^Error line (%d+) in file:')
+      if lnum then
+        table.insert(diagnostics, {
+          lnum = tonumber(lnum) - 1,
+          col = 0,
+          message = line,
+          severity = vim.diagnostic.severity.ERROR,
+        })
+      end
+    end
+    return diagnostics
+  end,
+  clean = function(ctx)
+    return { 'rm', '-f', (ctx.file:gsub('%.puml$', '.svg')) }
+  end,
+  open = true,
+}
+
+---@type preview.ProviderConfig
 M.quarto = {
   ft = 'quarto',
   cmd = { 'quarto' },


### PR DESCRIPTION
## Problem

PlantUML (`.puml`) diagrams have no built-in preview support.

## Solution

Add a `plantuml` preset that compiles to SVG via `plantuml -tsvg`, with an error parser for `Error line N` diagnostics. Add `plantuml` to the nix dev shell.