### PR TITLE
feat: add `mermaid` preset

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,7 @@
             pkgs.selene
             pkgs.lua-language-server
             pkgs.plantuml
+            pkgs.mermaid-cli
           ];
         };
       });

--- a/lua/preview/presets.lua
+++ b/lua/preview/presets.lua
@@ -303,6 +303,37 @@ M.plantuml = {
 }
 
 ---@type preview.ProviderConfig
+M.mermaid = {
+  ft = 'mermaid',
+  cmd = { 'mmdc' },
+  args = function(ctx)
+    return { '-i', ctx.file, '-o', ctx.output }
+  end,
+  output = function(ctx)
+    return (ctx.file:gsub('%.mmd$', '.svg'))
+  end,
+  error_parser = function(output)
+    local diagnostics = {}
+    for line in output:gmatch('[^\r\n]+') do
+      local lnum = line:match('^%s*Parse error on line (%d+)')
+      if lnum then
+        table.insert(diagnostics, {
+          lnum = tonumber(lnum) - 1,
+          col = 0,
+          message = line,
+          severity = vim.diagnostic.severity.ERROR,
+        })
+      end
+    end
+    return diagnostics
+  end,
+  clean = function(ctx)
+    return { 'rm', '-f', (ctx.file:gsub('%.mmd$', '.svg')) }
+  end,
+  open = true,
+}
+
+---@type preview.ProviderConfig
 M.quarto = {
   ft = 'quarto',
   cmd = { 'quarto' },


### PR DESCRIPTION
## Problem

No built-in support for compiling mermaid diagrams via `mmdc`.

## Solution

Add a `mermaid` preset that compiles `.mmd` files to SVG and parses
`Parse error on line N` diagnostics from stderr. Add `mermaid-cli` to
the nix dev shell.