### PR TITLE
ci: drop `--no-runtime-tags` from vimdoc check

### DIFF
--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -73,9 +73,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31
-      - run:
-          nix develop --command vimdoc-language-server check doc/
-          --no-runtime-tags
+      - run: nix develop --command vimdoc-language-server check doc/
 
   markdown-format:
     name: Markdown Format Check

--- a/flake.lock
+++ b/flake.lock
@@ -115,11 +115,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1773957462,
-        "narHash": "sha256-mBgdC5AC4fTn7vJEMND3pH4gfL5sFKAOu9C4mK2KR6o=",
+        "lastModified": 1773971251,
+        "narHash": "sha256-1w/uY96peWmnfdggu4t+Xr5DL1IK69MOGN75C4VHQzA=",
         "owner": "barrettruth",
         "repo": "vimdoc-language-server",
-        "rev": "b4c0a8cc4dbc3cc759ddc18fcec2365504b8b23e",
+        "rev": "51da455e37404d7defbf79cdf4289250080b0278",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Problem

vimdoc-language-server now auto-discovers `$VIMRUNTIME` by default.
The `--no-runtime-tags` flag suppresses this, causing false positives
on nvim builtin tag references in CI.

## Solution

Remove the flag and update the flake lockfile to pick up the new
vimdoc-language-server with auto-discovery support.