### PR TITLE
feat(github): add system theme and syntax
  highlighting

### DIFF
--- a/lua/preview/presets.lua
+++ b/lua/preview/presets.lua
@@ -244,17 +244,21 @@ M.github = {
   ft = 'markdown',
   cmd = { 'pandoc' },
   args = function(ctx)
-    return {
+    local template = vim.api.nvim_get_runtime_file('lua/preview/templates/gfm.html', false)[1]
+    local args = {
       '-f',
       'gfm',
       ctx.file,
       '-s',
       '--katex',
-      '--css',
-      'https://cdn.jsdelivr.net/gh/pixelbrackets/gfm-stylesheet@master/dist/gfm.css',
+      '--no-highlight',
       '-o',
       ctx.output,
     }
+    if template then
+      vim.list_extend(args, { '--template', template })
+    end
+    return args
   end,
   output = function(ctx)
     return (ctx.file:gsub('%.md$', '.html'))

--- a/lua/preview/templates/gfm.html
+++ b/lua/preview/templates/gfm.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"$if(lang)$ lang="$lang$" xml:lang="$lang$"$endif$>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+  <title>$if(title-prefix)$$title-prefix$ – $endif$$pagetitle$</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.8.1/github-markdown.min.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github.min.css" media="(prefers-color-scheme: light)" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github-dark.min.css" media="(prefers-color-scheme: dark)" />
+$if(math)$
+  $math$
+$endif$
+$for(header-includes)$
+  $header-includes$
+$endfor$
+</head>
+<body class="markdown-body" style="padding: 30px;">
+$if(title)$
+<h1>$title$</h1>
+$endif$
+$body$
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js"></script>
+<script>hljs.highlightAll();</script>
+</body>
+</html>

--- a/lua/preview/templates/gfm.html
+++ b/lua/preview/templates/gfm.html
@@ -1,25 +1,41 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"$if(lang)$ lang="$lang$" xml:lang="$lang$"$endif$>
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <title>$if(title-prefix)$$title-prefix$ – $endif$$pagetitle$</title>
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.8.1/github-markdown.min.css" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github.min.css" media="(prefers-color-scheme: light)" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github-dark.min.css" media="(prefers-color-scheme: dark)" />
-$if(math)$
-  $math$
-$endif$
-$for(header-includes)$
-  $header-includes$
-$endfor$
-</head>
-<body class="markdown-body" style="padding: 30px;">
-$if(title)$
-<h1>$title$</h1>
-$endif$
-$body$
-<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js"></script>
-<script>hljs.highlightAll();</script>
-</body>
+<!doctype html>
+<html
+  xmlns="http://www.w3.org/1999/xhtml"
+  $if(lang)$
+  lang="$lang$"
+  xml:lang="$lang$"
+  $endif$
+>
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, user-scalable=yes"
+    />
+    <title>$if(title-prefix)$$title-prefix$ – $endif$$pagetitle$</title>
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.8.1/github-markdown.min.css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github.min.css"
+      media="(prefers-color-scheme: light)"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github-dark.min.css"
+      media="(prefers-color-scheme: dark)"
+    />
+    $if(math)$ $math$ $endif$ $for(header-includes)$ $header-includes$ $endfor$
+  </head>
+  <body class="markdown-body" style="padding: 30px">
+    $if(title)$
+    <h1>$title$</h1>
+    $endif$ $body$
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js"></script>
+    <script>
+      hljs.highlightAll()
+    </script>
+  </body>
 </html>

--- a/spec/presets_spec.lua
+++ b/spec/presets_spec.lua
@@ -379,7 +379,7 @@ describe('presets', function()
       assert.are.same({ 'pandoc' }, presets.github.cmd)
     end)
 
-    it('returns args with standalone, katex, and css flags', function()
+    it('returns args with standalone, katex, and no-highlight flags', function()
       local args = presets.github.args(md_ctx)
       assert.is_table(args)
       assert.are.same({
@@ -388,10 +388,11 @@ describe('presets', function()
         '/tmp/document.md',
         '-s',
         '--katex',
-        '--css',
-        'https://cdn.jsdelivr.net/gh/pixelbrackets/gfm-stylesheet@master/dist/gfm.css',
+        '--no-highlight',
         '-o',
         '/tmp/document.html',
+        '--template',
+        vim.api.nvim_get_runtime_file('lua/preview/templates/gfm.html', false)[1],
       }, args)
     end)
 


### PR DESCRIPTION
## Problem

  The `github` preset used `pixelbrackets/gfm-stylesheet` which had no dark mode support, and pandoc's built-in syntax highlighting was a single static theme that didn't
  adapt to light/dark.

  ## Solution

  Switch to `sindresorhus/github-markdown-css` (auto light/dark via `prefers-color-scheme`) with a bundled pandoc template. Use highlight.js `github`/`github-dark`
  themes for theme-aware syntax highlighting via CSS `media` attributes. Pandoc runs with `--no-highlight` so highlight.js picks up standard code blocks client-side.