### PR TITLE
ci: use self-hosted runners

### DIFF
--- a/.github/workflows/luarocks.yaml
+++ b/.github/workflows/luarocks.yaml
@@ -11,7 +11,7 @@ jobs:
 
   publish:
     needs: quality
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, netcup, general]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -10,6 +10,8 @@ on:
 jobs:
   changes:
     runs-on: [self-hosted, linux, x64, netcup, general]
+    permissions:
+      pull-requests: read
     outputs:
       lua: ${{ steps.changes.outputs.lua }}
       markdown: ${{ steps.changes.outputs.markdown }}

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -18,9 +18,12 @@ jobs:
       vimdoc: ${{ steps.changes.outputs.vimdoc }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          path: repo
       - uses: dorny/paths-filter@v3
         id: changes
         with:
+          working-directory: repo
           filters: |
             lua:
               - 'lua/**'
@@ -40,8 +43,11 @@ jobs:
     if: ${{ needs.changes.outputs.lua == 'true' }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          path: repo
       - uses: cachix/install-nix-action@v31
       - run: nix develop --command stylua --check .
+        working-directory: repo
 
   lua-lint:
     name: Lua Lint Check
@@ -50,8 +56,11 @@ jobs:
     if: ${{ needs.changes.outputs.lua == 'true' }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          path: repo
       - uses: cachix/install-nix-action@v31
       - run: nix develop --command selene --display-style quiet .
+        working-directory: repo
 
   lua-typecheck:
     name: Lua Type Check
@@ -60,12 +69,14 @@ jobs:
     if: ${{ needs.changes.outputs.lua == 'true' }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          path: repo
       - name: Run Lua LS Type Check
         uses: mrcjkb/lua-typecheck-action@v0
         with:
           checklevel: Warning
-          directories: lua
-          configpath: .luarc.json
+          directories: repo/lua
+          configpath: repo/.luarc.json
 
   vimdoc-check:
     name: Vimdoc Check
@@ -74,8 +85,11 @@ jobs:
     if: ${{ needs.changes.outputs.vimdoc == 'true' }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          path: repo
       - uses: cachix/install-nix-action@v31
       - run: nix develop --command vimdoc-language-server check doc/
+        working-directory: repo
 
   markdown-format:
     name: Markdown Format Check
@@ -84,5 +98,8 @@ jobs:
     if: ${{ needs.changes.outputs.markdown == 'true' }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          path: repo
       - uses: cachix/install-nix-action@v31
       - run: nix develop --command prettier --check .
+        working-directory: repo

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   changes:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, netcup, general]
     outputs:
       lua: ${{ steps.changes.outputs.lua }}
       markdown: ${{ steps.changes.outputs.markdown }}
@@ -33,7 +33,7 @@ jobs:
 
   lua-format:
     name: Lua Format Check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, netcup, general]
     needs: changes
     if: ${{ needs.changes.outputs.lua == 'true' }}
     steps:
@@ -43,7 +43,7 @@ jobs:
 
   lua-lint:
     name: Lua Lint Check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, netcup, general]
     needs: changes
     if: ${{ needs.changes.outputs.lua == 'true' }}
     steps:
@@ -53,7 +53,7 @@ jobs:
 
   lua-typecheck:
     name: Lua Type Check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, netcup, general]
     needs: changes
     if: ${{ needs.changes.outputs.lua == 'true' }}
     steps:
@@ -67,7 +67,7 @@ jobs:
 
   vimdoc-check:
     name: Vimdoc Check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, netcup, general]
     needs: changes
     if: ${{ needs.changes.outputs.vimdoc == 'true' }}
     steps:
@@ -77,7 +77,7 @@ jobs:
 
   markdown-format:
     name: Markdown Format Check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, netcup, general]
     needs: changes
     if: ${{ needs.changes.outputs.markdown == 'true' }}
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,14 +17,15 @@ jobs:
         - /etc/static:/etc/static:ro
       env:
         SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+        TMPDIR: /github/home/tmp
     strategy:
       fail-fast: false
       matrix:
         nvim: [stable, nightly]
     name: Test (Neovim ${{ matrix.nvim }})
     steps:
+      - run: mkdir -p $TMPDIR && apt-get update && apt-get install -y sudo git
       - uses: actions/checkout@v4
-
       - uses: nvim-neorocks/nvim-busted-action@v1
         with:
           nvim_version: ${{ matrix.nvim }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,10 +13,7 @@ jobs:
       image: ubuntu:24.04
       volumes:
         - /nix/store:/nix/store:ro
-        - /etc/ssl:/etc/ssl:ro
-        - /etc/static:/etc/static:ro
       env:
-        SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
         TMPDIR: /github/home/tmp
     strategy:
       fail-fast: false
@@ -24,7 +21,12 @@ jobs:
         nvim: [stable, nightly]
     name: Test (Neovim ${{ matrix.nvim }})
     steps:
-      - run: mkdir -p $TMPDIR && apt-get update && apt-get install -y sudo git
+      - run: |
+          mkdir -p $TMPDIR
+          cert=$(ls /nix/store/*-nss-cacert-*/etc/ssl/certs/ca-bundle.crt 2>/dev/null | head -1)
+          echo "SSL_CERT_FILE=$cert" >> $GITHUB_ENV
+          echo "NODE_EXTRA_CA_CERTS=$cert" >> $GITHUB_ENV
+          apt-get update && apt-get install -y sudo git
       - uses: actions/checkout@v4
       - uses: nvim-neorocks/nvim-busted-action@v1
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, netcup, general]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,10 @@ jobs:
       image: ubuntu:24.04
       volumes:
         - /nix/store:/nix/store:ro
+        - /etc/ssl:/etc/ssl:ro
+        - /etc/static:/etc/static:ro
+      env:
+        SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   test:
     runs-on: [self-hosted, linux, x64, netcup, general]
+    container: ubuntu:24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,10 @@ on:
 jobs:
   test:
     runs-on: [self-hosted, linux, x64, netcup, general]
-    container: ubuntu:24.04
+    container:
+      image: ubuntu:24.04
+      volumes:
+        - /nix/store:/nix/store:ro
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,25 +9,18 @@ on:
 jobs:
   test:
     runs-on: [self-hosted, linux, x64, netcup, general]
-    container:
-      image: ubuntu:24.04
-      volumes:
-        - /nix/store:/nix/store:ro
-      env:
-        TMPDIR: /github/home/tmp
     strategy:
       fail-fast: false
       matrix:
         nvim: [stable, nightly]
     name: Test (Neovim ${{ matrix.nvim }})
     steps:
-      - run: |
-          mkdir -p $TMPDIR
-          cert=$(ls /nix/store/*-nss-cacert-*/etc/ssl/certs/ca-bundle.crt 2>/dev/null | head -1)
-          echo "SSL_CERT_FILE=$cert" >> $GITHUB_ENV
-          echo "NODE_EXTRA_CA_CERTS=$cert" >> $GITHUB_ENV
-          apt-get update && apt-get install -y sudo git
       - uses: actions/checkout@v4
-      - uses: nvim-neorocks/nvim-busted-action@v1
+      - uses: rhysd/action-setup-vim@v1
+        id: setup-vim
         with:
-          nvim_version: ${{ matrix.nvim }}
+          neovim: true
+          version: ${{ matrix.nvim }}
+      - run: |
+          export PATH="$(dirname '${{ steps.setup-vim.outputs.executable }}'):$PATH"
+          nix develop --command busted

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,6 +16,8 @@ jobs:
     name: Test (Neovim ${{ matrix.nvim }})
     steps:
       - uses: actions/checkout@v4
+        with:
+          path: repo
       - uses: rhysd/action-setup-vim@v1
         id: setup-vim
         with:
@@ -24,3 +26,4 @@ jobs:
       - run: |
           export PATH="$(dirname '${{ steps.setup-vim.outputs.executable }}'):$PATH"
           nix develop --command busted
+        working-directory: repo


### PR DESCRIPTION
## Summary
- Replace `runs-on: ubuntu-latest` with `runs-on: [self-hosted, linux, x64, netcup, general]` in all workflow files

#### Test plan
- [ ] All CI jobs run successfully on the self-hosted runner