### PR TITLE
revert(ci): restore GitHub-hosted runners

### DIFF
--- a/.github/workflows/luarocks.yaml
+++ b/.github/workflows/luarocks.yaml
@@ -11,7 +11,7 @@ jobs:
 
   publish:
     needs: quality
-    runs-on: [self-hosted, linux, x64, netcup, general]
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -9,21 +9,16 @@ on:
 
 jobs:
   changes:
-    runs-on: [self-hosted, linux, x64, netcup, general]
-    permissions:
-      pull-requests: read
+    runs-on: ubuntu-latest
     outputs:
       lua: ${{ steps.changes.outputs.lua }}
       markdown: ${{ steps.changes.outputs.markdown }}
       vimdoc: ${{ steps.changes.outputs.vimdoc }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          path: repo
       - uses: dorny/paths-filter@v3
         id: changes
         with:
-          working-directory: repo
           filters: |
             lua:
               - 'lua/**'
@@ -38,68 +33,54 @@ jobs:
 
   lua-format:
     name: Lua Format Check
-    runs-on: [self-hosted, linux, x64, netcup, general]
+    runs-on: ubuntu-latest
     needs: changes
     if: ${{ needs.changes.outputs.lua == 'true' }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          path: repo
       - uses: cachix/install-nix-action@v31
       - run: nix develop --command stylua --check .
-        working-directory: repo
 
   lua-lint:
     name: Lua Lint Check
-    runs-on: [self-hosted, linux, x64, netcup, general]
+    runs-on: ubuntu-latest
     needs: changes
     if: ${{ needs.changes.outputs.lua == 'true' }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          path: repo
       - uses: cachix/install-nix-action@v31
       - run: nix develop --command selene --display-style quiet .
-        working-directory: repo
 
   lua-typecheck:
     name: Lua Type Check
-    runs-on: [self-hosted, linux, x64, netcup, general]
+    runs-on: ubuntu-latest
     needs: changes
     if: ${{ needs.changes.outputs.lua == 'true' }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          path: repo
       - name: Run Lua LS Type Check
         uses: mrcjkb/lua-typecheck-action@v0
         with:
           checklevel: Warning
-          directories: repo/lua
-          configpath: repo/.luarc.json
+          directories: lua
+          configpath: .luarc.json
 
   vimdoc-check:
     name: Vimdoc Check
-    runs-on: [self-hosted, linux, x64, netcup, general]
+    runs-on: ubuntu-latest
     needs: changes
     if: ${{ needs.changes.outputs.vimdoc == 'true' }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          path: repo
       - uses: cachix/install-nix-action@v31
       - run: nix develop --command vimdoc-language-server check doc/
-        working-directory: repo
 
   markdown-format:
     name: Markdown Format Check
-    runs-on: [self-hosted, linux, x64, netcup, general]
+    runs-on: ubuntu-latest
     needs: changes
     if: ${{ needs.changes.outputs.markdown == 'true' }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          path: repo
       - uses: cachix/install-nix-action@v31
       - run: nix develop --command prettier --check .
-        working-directory: repo

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: [self-hosted, linux, x64, netcup, general]
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -16,14 +16,7 @@ jobs:
     name: Test (Neovim ${{ matrix.nvim }})
     steps:
       - uses: actions/checkout@v4
+
+      - uses: nvim-neorocks/nvim-busted-action@v1
         with:
-          path: repo
-      - uses: rhysd/action-setup-vim@v1
-        id: setup-vim
-        with:
-          neovim: true
-          version: ${{ matrix.nvim }}
-      - run: |
-          export PATH="$(dirname '${{ steps.setup-vim.outputs.executable }}'):$PATH"
-          nix develop --command busted
-        working-directory: repo
+          nvim_version: ${{ matrix.nvim }}


### PR DESCRIPTION
## Summary
- revert the self-hosted runner migration
- restore GitHub-hosted workflow execution for this repo
- remove the netcup runner dependency from CI

#### Test plan
- [x] Confirmed the revert removes `self-hosted` from the workflow files