### PR TITLE
build: add dev shell with preset tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,20 @@ luarocks install preview.nvim
 :help preview.nvim
 ```
 
+## Development
+
+Use the full preset-testing shell for manual validation:
+
+```sh
+nix develop .#dev
+```
+
+The lightweight CI shell remains available for scripted checks:
+
+```sh
+nix develop .#ci
+```
+
 ## FAQ
 
 **Q: How do I define a custom provider?**

--- a/flake.nix
+++ b/flake.nix
@@ -37,30 +37,34 @@
             pkgs.lua-language-server
             vimdoc-language-server.packages.${pkgs.system}.default
           ];
+          devPackages = devTools ++ [
+            pkgs.neovim
+            pkgs.typst
+            pkgs.texliveMedium
+            pkgs.tectonic
+            pkgs.pandoc
+            pkgs.asciidoctor
+            pkgs.quarto
+            pkgs.plantuml
+            pkgs.mermaid-cli
+            pkgs.zathura
+            pkgs.sioyek
+          ];
+          devShell = pkgs.mkShell {
+            packages = devPackages;
+          };
         in
         {
           default = pkgs.mkShell {
             packages = devTools;
           };
+          dev = devShell;
           ci = pkgs.mkShell {
             packages = devTools ++ [
               pkgs.neovim
             ];
           };
-          presets = pkgs.mkShell {
-            packages = devTools ++ [
-              pkgs.typst
-              pkgs.texliveMedium
-              pkgs.tectonic
-              pkgs.pandoc
-              pkgs.asciidoctor
-              pkgs.quarto
-              pkgs.plantuml
-              pkgs.mermaid-cli
-              pkgs.zathura
-              pkgs.sioyek
-            ];
-          };
+          presets = devShell;
         }
       );
     };


### PR DESCRIPTION
## Problem

Only `.#presets` bundled the binaries needed for manual preset validation, and it was split from the default dev shell so switching between development and preset testing was awkward.

## Solution

Add a `dev` shell containing devTools plus preset tooling (typst, texliveMedium, tectonic, pandoc, asciidoctor, quarto, plantuml, mermaid-cli, zathura, sioyek). Alias `presets` to the new shell for backwards compatibility. Document the available shells in the README.