### PR TITLE
feat(presets): add quarto error parser

### DIFF
--- a/lua/preview/presets.lua
+++ b/lua/preview/presets.lua
@@ -133,6 +133,39 @@ local function parse_mermaid(output)
   }
 end
 
+---@param output string
+---@return preview.Diagnostic[]
+local function parse_quarto(output)
+  output = output:gsub('\27%[[0-9;]*m', '')
+  local diagnostics = parse_pandoc(output)
+  if #diagnostics > 0 then
+    return diagnostics
+  end
+  local msg, lnum, col = output:match('ERROR:%s*([^\r\n]-)%s*%((%d+):(%d+)%)')
+  if msg then
+    return {
+      {
+        lnum = tonumber(lnum) - 1,
+        col = tonumber(col) - 1,
+        message = msg,
+        severity = vim.diagnostic.severity.ERROR,
+      },
+    }
+  end
+  msg = output:match('ERROR:%s*([^\r\n]+)')
+  if msg then
+    return {
+      {
+        lnum = 0,
+        col = 0,
+        message = msg,
+        severity = vim.diagnostic.severity.ERROR,
+      },
+    }
+  end
+  return {}
+end
+
 ---@type preview.ProviderConfig
 M.typst = {
   ft = 'typst',
@@ -352,6 +385,9 @@ M.quarto = {
   end,
   output = function(ctx)
     return (ctx.file:gsub('%.qmd$', '.html'))
+  end,
+  error_parser = function(output)
+    return parse_quarto(output)
   end,
   clean = function(ctx)
     local base = ctx.file:gsub('%.qmd$', '')

--- a/spec/fixtures/quarto.txt
+++ b/spec/fixtures/quarto.txt
@@ -1,0 +1,9 @@
+[91mERROR: YAMLException: missed comma between flow collection entries (3:1)
+
+ 1 |
+ 2 | title: [oops
+ 3 | format: html
+-----^
+
+Stack trace:
+    at generateError2 (file:///nix/store/example/bin/quarto.js:1:1)[39m

--- a/spec/presets_spec.lua
+++ b/spec/presets_spec.lua
@@ -706,8 +706,15 @@ describe('presets', function()
       assert.is_true(presets.quarto.reload)
     end)
 
-    it('has no error_parser', function()
-      assert.is_nil(presets.quarto.error_parser)
+    it('parses fixture output', function()
+      local diagnostics = presets.quarto.error_parser(helpers.read_fixture('quarto.txt'), qmd_ctx)
+      assert.are.equal(1, #diagnostics)
+      assert.are.equal(2, diagnostics[1].lnum)
+      assert.are.equal(0, diagnostics[1].col)
+      assert.are.equal(
+        'YAMLException: missed comma between flow collection entries',
+        diagnostics[1].message
+      )
     end)
   end)
 end)


### PR DESCRIPTION
## Problem

Quarto compilation failures were surfaced only as a generic notification, with no source location or file-specific diagnostic.

## Solution

Add a `parse_quarto` error parser that strips ANSI codes, delegates to the pandoc parser first (to catch underlying YAML and filter errors), and falls back to matching quarto's own `ERROR: msg (line:col)` format. Wire it into the `quarto` preset.

Based on #73 since it uses `helpers.read_fixture` introduced there.