### PR TITLE
ci: run quality checks in the .#ci devshell

### DIFF
--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31
-      - run: nix develop --command stylua --check .
+      - run: nix develop .#ci --command stylua --check .
 
   lua-lint:
     name: Lua Lint Check
@@ -49,7 +49,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31
-      - run: nix develop --command selene --display-style quiet .
+      - run: nix develop .#ci --command selene --display-style quiet .
 
   lua-typecheck:
     name: Lua Type Check
@@ -73,7 +73,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31
-      - run: nix develop --command vimdoc-language-server check doc/
+      - run: nix develop .#ci --command vimdoc-language-server check doc/
 
   markdown-format:
     name: Markdown Format Check
@@ -83,4 +83,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31
-      - run: nix develop --command prettier --check .
+      - run: nix develop .#ci --command prettier --check .


### PR DESCRIPTION
## Problem

Every quality workflow step shelled out with a bare `nix develop --command ...`, which enters the `default` shell. That shell intentionally omits `pkgs.neovim` so `nix develop` doesn't shadow a contributor's system neovim. The vimdoc check then runs without `$VIMRUNTIME`, so `vimdoc-language-server` can't resolve runtime tags like `|vim.ui.open()|`, `|:checkhealth|`, `|CursorMoved|` and `|CursorHold|` — a regression that only surfaces on the next PR that touches `doc/`.

## Solution

Point every workflow step at `.#ci`, which is `devTools ++ [pkgs.neovim]`. Matches `scripts/ci.sh`, keeps the default shell neovim-free for normal development, and gives vimdoc a real `$VIMRUNTIME` to read from.