### PR TITLE
ci: replace prettier with biome

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,9 +1,0 @@
-{
-  "proseWrap": "always",
-  "printWidth": 80,
-  "tabWidth": 2,
-  "useTabs": false,
-  "trailingComma": "none",
-  "semi": false,
-  "singleQuote": true
-}

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": true
+  },
+  "formatter": {
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 80
+  },
+  "linter": {
+    "enabled": false
+  },
+  "assist": {
+    "enabled": false
+  }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
               ]
             ))
             pkgs.just
-            pkgs.prettier
+            pkgs.biome
             pkgs.stylua
             pkgs.selene
             pkgs.lua-language-server

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ default:
 format:
     nix fmt -- --ci
     stylua --check .
-    prettier --check .
+    biome ci .
 
 lint:
     git ls-files '*.lua' | xargs selene --display-style quiet


### PR DESCRIPTION
Replace the repo-level Prettier check with Biome in preview.nvim. This adds a Biome config that ignores unsupported files and respects gitignore, swaps the Nix dev shell from `pkgs.prettier` to `pkgs.biome`, updates `just format` to run `biome ci .`, and removes the old Prettier config.

I verified the change with `direnv exec /tmp/preview.nvim/replace-prettier-with-biome bash -lc 'cd /tmp/preview.nvim/replace-prettier-with-biome && just ci'`.
