### PR TITLE
fix: improve failed compile output discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ Okular.
 
 **Q: How do I inspect the full compiler output?**
 
-Use:
+If a compile fails, check diagnostics or quickfix first when available. For the
+raw compiler output, use:
 
 ```vim
 :Preview output
@@ -128,4 +129,6 @@ Use:
 
 Compilation failures intentionally use a short generic notification. The full
 raw compiler output is available through `:Preview output` and
-`require('preview').result()`.
+`require('preview').result()`. One-shot providers replace the stored output on
+each compile. Long-running providers such as `typst watch` show the current
+watch-session log.

--- a/doc/preview.nvim.txt
+++ b/doc/preview.nvim.txt
@@ -237,7 +237,7 @@ COMMANDS                                                    *preview-commands*
     `compile`    One-shot compile of the current buffer.
     `clean`      Run the provider's clean command.
     `open`       Open the last compiled output without recompiling.
-    `output`     Open the last compiler output for the current buffer.
+    `output`     Open the stored raw compiler output for the current buffer.
     `status`     Echo compilation status (idle, compiling, watching).
 
 ==============================================================================
@@ -262,7 +262,9 @@ preview.open({bufnr?})                                        *preview.open()*
     Open the last compiled output for the buffer without recompiling.
 
 preview.output({bufnr?})                                    *preview.output()*
-    Open the last compiler output for the buffer in a scratch split.
+    Open the stored raw compiler output for the buffer in a scratch split.
+    One-shot providers replace the stored output on each compile. Long-running
+    providers append to the current watch-session log.
 
 preview.result({bufnr?})                                    *preview.result()*
     Returns a |preview.Result| table for the buffer, or `nil` if no
@@ -357,9 +359,12 @@ A: Override the `output` field. The `args` function references `ctx.output`,
 
 Q: How do I inspect the full compiler output?
 
-A: Use |:Preview| `output` to open the last compiler output in a scratch
-   split. Compile failure notifications are intentionally terse; use
-   |preview.result()| or |:Preview| `output` when you need the raw output.
+A: If a compile fails, check diagnostics or quickfix first when available.
+   Use |:Preview| `output` to open the stored raw compiler output in a scratch
+   split. One-shot providers replace the stored output on each compile.
+   Long-running providers append to the current watch-session log. Compile
+   failure notifications are intentionally terse; use |preview.result()| or
+   |:Preview| `output` when you need the raw output.
 
 ==============================================================================
 SYNCTEX                                                      *preview-synctex*

--- a/lua/preview/compiler.lua
+++ b/lua/preview/compiler.lua
@@ -122,6 +122,15 @@ local function clear_errors(bufnr, provider)
   end
 end
 
+---@param error_count integer
+---@return string
+local function compile_failed_message(error_count)
+  if error_count > 0 then
+    return '[preview.nvim]: compilation failed'
+  end
+  return '[preview.nvim]: compilation failed (see :Preview output)'
+end
+
 ---@param output_bufnr integer
 ---@param output? string
 local function set_output_lines(output_bufnr, output)
@@ -355,7 +364,7 @@ function M.compile(bufnr, name, provider, ctx, opts)
           local count = handle_errors(bufnr, name, provider, ctx, stderr)
           if count > 0 and not s.has_errors then
             s.has_errors = true
-            vim.notify('[preview.nvim]: compilation failed', vim.log.levels.ERROR)
+            vim.notify(compile_failed_message(count), vim.log.levels.ERROR)
           end
         end),
       },
@@ -383,8 +392,8 @@ function M.compile(bufnr, name, provider, ctx, opts)
             })
           end
           log.dbg('long-running process failed for buffer %d (exit code %d)', bufnr, result.code)
-          vim.notify('[preview.nvim]: compilation failed', vim.log.levels.ERROR)
-          handle_errors(bufnr, name, provider, ctx, output)
+          local count = handle_errors(bufnr, name, provider, ctx, output)
+          vim.notify(compile_failed_message(count), vim.log.levels.ERROR)
           vim.api.nvim_exec_autocmds('User', {
             pattern = 'PreviewCompileFailed',
             data = {
@@ -567,8 +576,8 @@ function M.compile(bufnr, name, provider, ctx, opts)
         end
       else
         log.dbg('compilation failed for buffer %d (exit code %d)', bufnr, result.code)
-        vim.notify('[preview.nvim]: compilation failed', vim.log.levels.ERROR)
-        handle_errors(bufnr, name, provider, ctx, output)
+        local count = handle_errors(bufnr, name, provider, ctx, output)
+        vim.notify(compile_failed_message(count), vim.log.levels.ERROR)
         vim.api.nvim_exec_autocmds('User', {
           pattern = 'PreviewCompileFailed',
           data = {

--- a/spec/compiler_spec.lua
+++ b/spec/compiler_spec.lua
@@ -176,7 +176,7 @@ describe('compiler', function()
       helpers.delete_buffer(bufnr)
     end)
 
-    it('notifies generically on compile failure', function()
+    it('notifies generically on compile failure when structured errors exist', function()
       local bufnr = helpers.create_buffer({ 'hello' }, 'text')
       vim.api.nvim_buf_set_name(bufnr, '/tmp/preview_test_fail_summary.txt')
       vim.bo[bufnr].modified = false
@@ -209,6 +209,45 @@ exit 12]],
       local ctx = {
         bufnr = bufnr,
         file = '/tmp/preview_test_fail_summary.txt',
+        root = '/tmp',
+        ft = 'text',
+      }
+
+      compiler.compile(bufnr, 'falsecmd', provider, ctx)
+
+      vim.wait(2000, function()
+        return process_done(bufnr)
+      end, 50)
+
+      vim.notify = orig
+      assert.is_true(notified)
+      helpers.delete_buffer(bufnr)
+    end)
+
+    it('hints :Preview output when compile failure has no structured errors', function()
+      local bufnr = helpers.create_buffer({ 'hello' }, 'text')
+      vim.api.nvim_buf_set_name(bufnr, '/tmp/preview_test_fail_output_hint.txt')
+      vim.bo[bufnr].modified = false
+
+      local notified = false
+      local orig = vim.notify
+      vim.notify = function(msg, level)
+        if msg == '[preview.nvim]: compilation failed (see :Preview output)' then
+          notified = level == vim.log.levels.ERROR
+        end
+      end
+
+      local provider = {
+        cmd = {
+          'sh',
+          '-c',
+          [[printf '%s\n' 'fatal compiler output' >&2
+exit 12]],
+        },
+      }
+      local ctx = {
+        bufnr = bufnr,
+        file = '/tmp/preview_test_fail_output_hint.txt',
         root = '/tmp',
         ft = 'text',
       }
@@ -412,6 +451,44 @@ exit 12]],
       vim.wait(2000, function()
         return process_done(bufnr)
       end, 50)
+      helpers.delete_buffer(bufnr)
+    end)
+
+    it('hints :Preview output when long-running compile exits without structured errors', function()
+      local bufnr = helpers.create_buffer({ 'hello' }, 'text')
+      vim.api.nvim_buf_set_name(bufnr, '/tmp/preview_test_longrun_output_hint.txt')
+      vim.bo[bufnr].modified = false
+
+      local notified_fail = false
+      local orig = vim.notify
+      vim.notify = function(msg, level)
+        if msg == '[preview.nvim]: compilation failed (see :Preview output)' then
+          notified_fail = level == vim.log.levels.ERROR
+        end
+      end
+
+      local provider = {
+        cmd = { 'sh' },
+        reload = function()
+          return { 'sh', '-c', 'echo "fatal compiler output" >&2; exit 12' }
+        end,
+      }
+      local ctx = {
+        bufnr = bufnr,
+        file = '/tmp/preview_test_longrun_output_hint.txt',
+        root = '/tmp',
+        ft = 'text',
+      }
+
+      compiler.compile(bufnr, 'testprov', provider, ctx)
+
+      vim.wait(3000, function()
+        return notified_fail
+      end, 50)
+
+      vim.notify = orig
+      assert.is_true(notified_fail)
+      assert.is_truthy(compiler.result(bufnr).output:find('fatal compiler output', 1, true))
       helpers.delete_buffer(bufnr)
     end)
   end)


### PR DESCRIPTION
Why: `:Preview output` and `preview.result()` were still easy to miss on failure, and the docs were misleading for long-running providers.\n\nHow: Clarify the failure workflow in the README FAQ and `:help preview.nvim`, document stored raw-output semantics for one-shot versus long-running providers, and hint `:Preview output` only when a failure produced no structured diagnostics or quickfix entries.