### PR TITLE
chore: add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,101 @@
+name: Bug Report
+description: Report a bug
+title: 'bug: '
+labels: [bug]
+body:
+  - type: checkboxes
+    attributes:
+      label: Prerequisites
+      options:
+        - label:
+            I have searched [existing
+            issues](https://github.com/barrettruth/preview.nvim/issues)
+          required: true
+        - label: I have updated to the latest version
+          required: true
+
+  - type: textarea
+    attributes:
+      label: 'Neovim version'
+      description: 'Output of `nvim --version`'
+      render: text
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: 'Operating system'
+      placeholder: 'e.g. Arch Linux, macOS 15, Ubuntu 24.04'
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Provider or filetype
+      placeholder: 'e.g. typst, tex, markdown, github, quarto, custom provider'
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Description
+      description: What happened? What did you expect?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to trigger the bug
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: 'Health check'
+      description: 'Output of `:checkhealth preview`'
+      render: text
+
+  - type: textarea
+    attributes:
+      label: 'Compiler output'
+      description: 'Relevant output from `:Preview output` or `require(''preview'').result()`'
+      render: text
+
+  - type: textarea
+    attributes:
+      label: Preview config
+      description: 'Relevant `vim.g.preview` or `require(''preview'').setup(...)` config'
+      render: lua
+
+  - type: textarea
+    attributes:
+      label: Minimal reproduction
+      description: |
+        Save the script below as `repro.lua`, edit it to match your provider and compiler setup, and run:
+        ```
+        nvim -u repro.lua
+        ```
+        Confirm the bug reproduces with this config before submitting.
+      render: lua
+      value: |
+        vim.env.LAZY_STDPATH = '.repro'
+        load(vim.fn.system('curl -s https://raw.githubusercontent.com/folke/lazy.nvim/main/bootstrap.lua'))()
+        require('lazy.nvim').setup({
+          spec = {
+            {
+              'barrettruth/preview.nvim',
+              init = function()
+                vim.g.preview = {
+                  typst = true,
+                }
+              end,
+            },
+          },
+        })
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,30 @@
+name: Feature Request
+description: Suggest a feature
+title: 'feat: '
+labels: [enhancement]
+body:
+  - type: checkboxes
+    attributes:
+      label: Prerequisites
+      options:
+        - label:
+            I have searched [existing
+            issues](https://github.com/barrettruth/preview.nvim/issues)
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Problem
+      description: What problem does this solve?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Proposed solution
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Alternatives considered

--- a/.github/ISSUE_TEMPLATE/question.yaml
+++ b/.github/ISSUE_TEMPLATE/question.yaml
@@ -1,0 +1,22 @@
+name: Question
+description: Ask a question about using preview.nvim
+title: 'question: '
+labels: [question]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for usage questions or general discussion about preview.nvim.
+        For bug reports, please use the bug report form instead.
+        For feature ideas, please use the feature request form instead.
+
+  - type: textarea
+    attributes:
+      label: Question
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Context
+      description: Relevant details such as provider or filetype, config, `:checkhealth preview`, compiler output, or screenshots

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+## Why
+
+
+## How
+
+
+## Testing


### PR DESCRIPTION
## Why

preview.nvim did not have GitHub issue forms or a pull request template, so bug reports, feature requests, and questions were missing consistent project-specific context.

## How

Add preview.nvim-specific GitHub issue forms for bugs, features, and questions, plus issue config to disable blank issues. Add a minimal pull request template with `Why`, `How`, and `Testing` sections.

## Testing

Ran `nix develop .#ci --command just ci` and parsed all `.github/ISSUE_TEMPLATE/*.yaml` files with `PyYAML`.
