### PR TITLE
feat(api): add provider failure summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ vim.g.preview = {
     output = function(ctx)
       return ctx.file:gsub('%.rst$', '.html')
     end,
+    failure_summary = function(result)
+      return result.output:match('^ERROR:%s*(.+)$')
+    end,
   },
 }
 ```
@@ -127,8 +130,9 @@ raw compiler output, use:
 :Preview output
 ```
 
-Compilation failures intentionally use a short generic notification. The full
-raw compiler output is available through `:Preview output` and
+Compilation failures intentionally use a short notification. Providers can
+optionally define `failure_summary(result, ctx)` to customize that message. The
+full raw compiler output is available through `:Preview output` and
 `require('preview').result()`. One-shot providers replace the stored output on
 each compile. Long-running providers such as `typst watch` show the current
 watch-session log.

--- a/doc/preview.nvim.txt
+++ b/doc/preview.nvim.txt
@@ -86,6 +86,16 @@ Provider fields: ~
   {error_parser}     (function)         Receives (output, |preview.Context|)
                                         and returns vim.Diagnostic[].
 
+  {failure_summary}  (function)         Receives (|preview.Result|,
+                                        |preview.Context|) and returns a short
+                                        string shown after the `[preview.nvim]:`
+                                        prefix on failure. Return `nil` to fall
+                                        back to the generic failure message.
+                                        In long-running providers, this may run
+                                        before process exit, so `{code}` can be
+                                        `nil` and `{output}` is the accumulated
+                                        output so far.
+
   {errors}           (false|'diagnostic'|'quickfix')
                                         How parse errors are reported.
                                         `false` suppresses error handling.
@@ -166,6 +176,9 @@ Example with a fully custom provider (key is not a preset name): >lua
         end,
         output = function(ctx)
           return ctx.file:gsub('%.rst$', '.html')
+        end,
+        failure_summary = function(result)
+          return result.output:match('^ERROR:%s*(.+)$')
         end,
       },
     }
@@ -362,9 +375,10 @@ Q: How do I inspect the full compiler output?
 A: If a compile fails, check diagnostics or quickfix first when available.
    Use |:Preview| `output` to open the stored raw compiler output in a scratch
    split. One-shot providers replace the stored output on each compile.
-   Long-running providers append to the current watch-session log. Compile
-   failure notifications are intentionally terse; use |preview.result()| or
-   |:Preview| `output` when you need the raw output.
+   Long-running providers append to the current watch-session log. Providers
+   can optionally define `failure_summary(result, ctx)` for a short failure
+   notification, but |preview.result()| and |:Preview| `output` remain the raw
+   inspection path.
 
 ==============================================================================
 SYNCTEX                                                      *preview-synctex*

--- a/lua/preview/compiler.lua
+++ b/lua/preview/compiler.lua
@@ -122,9 +122,51 @@ local function clear_errors(bufnr, provider)
   end
 end
 
+---@param summary string?
+---@return string?
+local function normalize_failure_summary(summary)
+  if type(summary) ~= 'string' then
+    return nil
+  end
+  summary = summary:gsub('%s+', ' '):gsub('^%s+', ''):gsub('%s+$', '')
+  if summary == '' then
+    return nil
+  end
+  return summary
+end
+
+---@param name string
+---@param provider preview.ProviderConfig
+---@param result preview.Result?
+---@param ctx preview.Context
+---@return string?
+local function failure_summary_message(name, provider, result, ctx)
+  if not (provider.failure_summary and result) then
+    return nil
+  end
+  local ok, summary = pcall(provider.failure_summary, result, ctx)
+  if not ok then
+    log.dbg('failure_summary for "%s" failed: %s', name, summary)
+    return nil
+  end
+  summary = normalize_failure_summary(summary)
+  if not summary then
+    return nil
+  end
+  return '[preview.nvim]: ' .. summary
+end
+
+---@param name string
+---@param provider preview.ProviderConfig
+---@param result preview.Result?
+---@param ctx preview.Context
 ---@param error_count integer
 ---@return string
-local function compile_failed_message(error_count)
+local function compile_failed_message(name, provider, result, ctx, error_count)
+  local summary = failure_summary_message(name, provider, result, ctx)
+  if summary then
+    return summary
+  end
   if error_count > 0 then
     return '[preview.nvim]: compilation failed'
   end
@@ -361,10 +403,13 @@ function M.compile(bufnr, name, provider, ctx, opts)
             output = data,
           })
           local stderr = table.concat(stderr_acc)
-          local count = handle_errors(bufnr, name, provider, ctx, stderr)
+          local count = handle_errors(bufnr, name, provider, resolved_ctx, stderr)
           if count > 0 and not s.has_errors then
             s.has_errors = true
-            vim.notify(compile_failed_message(count), vim.log.levels.ERROR)
+            vim.notify(
+              compile_failed_message(name, provider, results[bufnr], resolved_ctx, count),
+              vim.log.levels.ERROR
+            )
           end
         end),
       },
@@ -392,8 +437,11 @@ function M.compile(bufnr, name, provider, ctx, opts)
             })
           end
           log.dbg('long-running process failed for buffer %d (exit code %d)', bufnr, result.code)
-          local count = handle_errors(bufnr, name, provider, ctx, output)
-          vim.notify(compile_failed_message(count), vim.log.levels.ERROR)
+          local count = handle_errors(bufnr, name, provider, resolved_ctx, output)
+          vim.notify(
+            compile_failed_message(name, provider, results[bufnr], resolved_ctx, count),
+            vim.log.levels.ERROR
+          )
           vim.api.nvim_exec_autocmds('User', {
             pattern = 'PreviewCompileFailed',
             data = {
@@ -576,8 +624,11 @@ function M.compile(bufnr, name, provider, ctx, opts)
         end
       else
         log.dbg('compilation failed for buffer %d (exit code %d)', bufnr, result.code)
-        local count = handle_errors(bufnr, name, provider, ctx, output)
-        vim.notify(compile_failed_message(count), vim.log.levels.ERROR)
+        local count = handle_errors(bufnr, name, provider, resolved_ctx, output)
+        vim.notify(
+          compile_failed_message(name, provider, results[bufnr], resolved_ctx, count),
+          vim.log.levels.ERROR
+        )
         vim.api.nvim_exec_autocmds('User', {
           pattern = 'PreviewCompileFailed',
           data = {

--- a/lua/preview/init.lua
+++ b/lua/preview/init.lua
@@ -7,6 +7,7 @@
 ---@field env? table<string, string>
 ---@field output? string|fun(ctx: preview.Context): string
 ---@field error_parser? fun(output: string, ctx: preview.Context): preview.Diagnostic[]
+---@field failure_summary? fun(result: preview.Result, ctx: preview.Context): string?
 ---@field errors? false|'diagnostic'|'quickfix'
 ---@field clean? string[]|fun(ctx: preview.Context): string[]
 ---@field open? boolean|string[]
@@ -111,6 +112,7 @@ function M.setup(opts)
     vim.validate(prefix .. '.cwd', provider.cwd, { 'string', 'function' }, true)
     vim.validate(prefix .. '.output', provider.output, { 'string', 'function' }, true)
     vim.validate(prefix .. '.error_parser', provider.error_parser, 'function', true)
+    vim.validate(prefix .. '.failure_summary', provider.failure_summary, 'function', true)
     vim.validate(prefix .. '.errors', provider.errors, function(x)
       return x == nil or x == false or x == 'diagnostic' or x == 'quickfix'
     end, 'false, "diagnostic", or "quickfix"')

--- a/spec/compiler_spec.lua
+++ b/spec/compiler_spec.lua
@@ -263,6 +263,151 @@ exit 12]],
       helpers.delete_buffer(bufnr)
     end)
 
+    it('uses provider failure summary on compile failure', function()
+      local bufnr = helpers.create_buffer({ 'hello' }, 'text')
+      vim.api.nvim_buf_set_name(bufnr, '/tmp/preview_test_fail_custom_summary.txt')
+      vim.bo[bufnr].modified = false
+
+      local notified = false
+      local captured = {}
+      local orig = vim.notify
+      vim.notify = function(msg, level)
+        if msg == '[preview.nvim]: bad input' then
+          notified = level == vim.log.levels.ERROR
+        end
+      end
+
+      local provider = {
+        cmd = {
+          'sh',
+          '-c',
+          [[printf '%s\n' 'error: bad input' >&2
+exit 12]],
+        },
+        error_parser = function()
+          return {
+            {
+              lnum = 0,
+              col = 0,
+              message = 'diagnostic error',
+              severity = vim.diagnostic.severity.ERROR,
+            },
+          }
+        end,
+        failure_summary = function(result, ctx)
+          captured.code = result.code
+          captured.output = result.output
+          captured.file = ctx.file
+          captured.output_file = ctx.output
+          return 'bad input'
+        end,
+      }
+      local ctx = {
+        bufnr = bufnr,
+        file = '/tmp/preview_test_fail_custom_summary.txt',
+        root = '/tmp',
+        ft = 'text',
+      }
+
+      compiler.compile(bufnr, 'falsecmd', provider, ctx)
+
+      vim.wait(2000, function()
+        return process_done(bufnr)
+      end, 50)
+
+      vim.notify = orig
+      assert.is_true(notified)
+      assert.are.equal(12, captured.code)
+      assert.are.equal('/tmp/preview_test_fail_custom_summary.txt', captured.file)
+      assert.are.equal('', captured.output_file)
+      assert.is_truthy(captured.output:find('bad input', 1, true))
+      helpers.delete_buffer(bufnr)
+    end)
+
+    it('falls back when provider failure summary returns nil', function()
+      local bufnr = helpers.create_buffer({ 'hello' }, 'text')
+      vim.api.nvim_buf_set_name(bufnr, '/tmp/preview_test_fail_nil_summary.txt')
+      vim.bo[bufnr].modified = false
+
+      local notified = false
+      local orig = vim.notify
+      vim.notify = function(msg, level)
+        if msg == '[preview.nvim]: compilation failed (see :Preview output)' then
+          notified = level == vim.log.levels.ERROR
+        end
+      end
+
+      local provider = {
+        cmd = {
+          'sh',
+          '-c',
+          [[printf '%s\n' 'fatal compiler output' >&2
+exit 12]],
+        },
+        failure_summary = function()
+          return nil
+        end,
+      }
+      local ctx = {
+        bufnr = bufnr,
+        file = '/tmp/preview_test_fail_nil_summary.txt',
+        root = '/tmp',
+        ft = 'text',
+      }
+
+      compiler.compile(bufnr, 'falsecmd', provider, ctx)
+
+      vim.wait(2000, function()
+        return process_done(bufnr)
+      end, 50)
+
+      vim.notify = orig
+      assert.is_true(notified)
+      helpers.delete_buffer(bufnr)
+    end)
+
+    it('falls back when provider failure summary errors', function()
+      local bufnr = helpers.create_buffer({ 'hello' }, 'text')
+      vim.api.nvim_buf_set_name(bufnr, '/tmp/preview_test_fail_erroring_summary.txt')
+      vim.bo[bufnr].modified = false
+
+      local notified = false
+      local orig = vim.notify
+      vim.notify = function(msg, level)
+        if msg == '[preview.nvim]: compilation failed (see :Preview output)' then
+          notified = level == vim.log.levels.ERROR
+        end
+      end
+
+      local provider = {
+        cmd = {
+          'sh',
+          '-c',
+          [[printf '%s\n' 'fatal compiler output' >&2
+exit 12]],
+        },
+        failure_summary = function()
+          error('boom')
+        end,
+      }
+      local ctx = {
+        bufnr = bufnr,
+        file = '/tmp/preview_test_fail_erroring_summary.txt',
+        root = '/tmp',
+        ft = 'text',
+      }
+
+      compiler.compile(bufnr, 'falsecmd', provider, ctx)
+
+      vim.wait(2000, function()
+        return process_done(bufnr)
+      end, 50)
+
+      vim.notify = orig
+      assert.is_true(notified)
+      helpers.delete_buffer(bufnr)
+    end)
+
     it('stores full process output on failure', function()
       local bufnr = helpers.create_buffer({ 'hello' }, 'text')
       vim.api.nvim_buf_set_name(bufnr, '/tmp/preview_test_fail_result.txt')
@@ -446,6 +591,68 @@ exit 12]],
       local s = compiler._test.state[bufnr]
       assert.is_true(s.has_errors)
       assert.is_truthy(compiler.result(bufnr).output:find('bad input', 1, true))
+
+      compiler.stop(bufnr)
+      vim.wait(2000, function()
+        return process_done(bufnr)
+      end, 50)
+      helpers.delete_buffer(bufnr)
+    end)
+
+    it('uses provider failure summary for long-running failures', function()
+      local bufnr = helpers.create_buffer({ 'hello' }, 'text')
+      vim.api.nvim_buf_set_name(bufnr, '/tmp/preview_test_longrun_custom_summary.txt')
+      vim.bo[bufnr].modified = false
+
+      local notified_fail = false
+      local captured = {}
+      local orig = vim.notify
+      vim.notify = function(msg, level)
+        if msg == '[preview.nvim]: bad input' and level == vim.log.levels.ERROR then
+          notified_fail = true
+        end
+      end
+
+      local provider = {
+        cmd = { 'sh' },
+        reload = function()
+          return { 'sh', '-c', 'echo "error: bad input" >&2; sleep 60' }
+        end,
+        error_parser = function()
+          return {
+            {
+              lnum = 0,
+              col = 0,
+              message = 'bad input',
+              severity = vim.diagnostic.severity.ERROR,
+            },
+          }
+        end,
+        failure_summary = function(result, ctx)
+          captured.code = result.code
+          captured.output = result.output
+          captured.file = ctx.file
+          return 'bad input'
+        end,
+      }
+      local ctx = {
+        bufnr = bufnr,
+        file = '/tmp/preview_test_longrun_custom_summary.txt',
+        root = '/tmp',
+        ft = 'text',
+      }
+
+      compiler.compile(bufnr, 'testprov', provider, ctx)
+
+      vim.wait(3000, function()
+        return notified_fail
+      end, 50)
+
+      vim.notify = orig
+      assert.is_true(notified_fail)
+      assert.is_nil(captured.code)
+      assert.are.equal('/tmp/preview_test_longrun_custom_summary.txt', captured.file)
+      assert.is_truthy(captured.output:find('bad input', 1, true))
 
       compiler.stop(bufnr)
       vim.wait(2000, function()

--- a/spec/init_spec.lua
+++ b/spec/init_spec.lua
@@ -54,6 +54,20 @@ describe('preview', function()
       local presets = require('preview.presets')
       assert.are.same(presets.github, config.providers.markdown)
     end)
+
+    it('accepts failure_summary on custom providers', function()
+      local summary = function()
+        return 'bad input'
+      end
+      helpers.reset_config({
+        text = {
+          cmd = { 'cat' },
+          failure_summary = summary,
+        },
+      })
+      local config = require('preview').get_config()
+      assert.are.equal(summary, config.providers.text.failure_summary)
+    end)
   end)
 
   describe('resolve_provider', function()


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

Custom providers can parse diagnostics and expose raw output, but they cannot participate in the short failure notification. That makes failure UX harder to extend without pushing format-specific behavior into the compiler.

## Solution

Add an optional `failure_summary(result, ctx)` provider hook, validate and document it, and route failure notifications through it before falling back to the existing generic and `:Preview output` hint path. Add focused config and compiler tests for one-shot and long-running providers, plus fallback behavior when the hook returns `nil` or errors.
