### PR TITLE
feat(latex): summarize latexmk failures

### DIFF
--- a/lua/preview/presets.lua
+++ b/lua/preview/presets.lua
@@ -51,6 +51,22 @@ local function parse_latexmk(output)
 end
 
 ---@param output string
+---@return string?
+local function summarize_latexmk(output)
+  for line in output:gmatch('[^\r\n]+') do
+    local fpath, lnum, msg = line:match('^%.?/?(.+%.tex):(%d+):%s*(.+)$')
+    if fpath and msg and not msg:match('^%s*==>') then
+      local fname = fpath:match('([^/]+)$') or fpath
+      return string.format('%s:%s: %s', fname, lnum, msg)
+    end
+    local bang = line:match('^!%s+(.+)$')
+    if bang and not bang:match('^%s*==>') then
+      return bang
+    end
+  end
+end
+
+---@param output string
 ---@return preview.Diagnostic[]
 local function parse_pandoc(output)
   local diagnostics = {}
@@ -206,6 +222,9 @@ M.latex = {
   end,
   error_parser = function(output)
     return parse_latexmk(output)
+  end,
+  failure_summary = function(result)
+    return summarize_latexmk(result.output or '')
   end,
   clean = function(ctx)
     return { 'latexmk', '-c', ctx.file }

--- a/spec/fixtures/latexmk_emergency_stop.txt
+++ b/spec/fixtures/latexmk_emergency_stop.txt
@@ -1,0 +1,50 @@
+Rc files read:
+  NONE
+Latexmk: This is Latexmk, John Collins, 15 June 2025. Version 4.87.
+No existing .aux file, so I'll make a simple one, and require run of *latex.
+Latexmk: applying rule 'pdflatex'...
+Rule 'pdflatex':  Reasons for rerun
+Category 'other':
+  Rerun of 'pdflatex' forced or previously required:
+    Reason or flag: 'Initial setup'
+
+------------
+Run number 1 of rule 'pdflatex'
+------------
+------------
+Running 'pdflatex -file-line-error -interaction=nonstopmode  -interaction=nonstopmode -synctex=1 -recorder  "document.tex"'
+------------
+This is pdfTeX, Version 3.141592653-2.6-1.40.27 (TeX Live 2025/nixos.org) (preloaded format=pdflatex)
+ restricted \write18 enabled.
+entering extended mode
+(./document.tex
+LaTeX2e <2025-11-01>
+L3 programming layer <2026-01-19>
+)
+Runaway argument?
+{article \begin {document} This will trigger an emergency stop becaus\ETC.
+! File ended while scanning use of \@fileswith@ptions.
+<inserted text> 
+                \par 
+<*> document.tex
+                
+! Emergency stop.
+<*> document.tex
+                
+!  ==> Fatal error occurred, no output PDF file produced!
+Transcript written on document.log.
+Latexmk: Getting log file 'document.log'
+Latexmk: Examining 'document.fls'
+Latexmk: Examining 'document.log'
+Latexmk: Errors, so I did not complete making targets
+Collected error summary (may duplicate other messages):
+  pdflatex: Command for 'pdflatex' gave return code 1
+      Refer to 'document.log' and/or above output for details
+
+Latexmk: Using bibtex to make bibliography file(s).
+Latexmk: Sometimes, the -f option can be used to get latexmk
+  to try to force complete processing.
+  But normally, you will need to correct the file(s) that caused the
+  error, and then rerun latexmk.
+  In some cases, it is best to clean out generated files before rerunning
+  latexmk after you've corrected the files.

--- a/spec/fixtures/latexmk_missing_pkg.txt
+++ b/spec/fixtures/latexmk_missing_pkg.txt
@@ -1,0 +1,60 @@
+Rc files read:
+  NONE
+Latexmk: This is Latexmk, John Collins, 15 June 2025. Version 4.87.
+No existing .aux file, so I'll make a simple one, and require run of *latex.
+Latexmk: applying rule 'pdflatex'...
+Rule 'pdflatex':  Reasons for rerun
+Category 'other':
+  Rerun of 'pdflatex' forced or previously required:
+    Reason or flag: 'Initial setup'
+
+------------
+Run number 1 of rule 'pdflatex'
+------------
+------------
+Running 'pdflatex -file-line-error -interaction=nonstopmode  -interaction=nonstopmode -synctex=1 -recorder  "document.tex"'
+------------
+This is pdfTeX, Version 3.141592653-2.6-1.40.27 (TeX Live 2025/nixos.org) (preloaded format=pdflatex)
+ restricted \write18 enabled.
+entering extended mode
+(./document.tex
+LaTeX2e <2025-11-01>
+L3 programming layer <2026-01-19>
+
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/
+base/article.cls
+Document Class: article 2025/01/22 v1.4n Standard LaTeX document class
+
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/
+base/size10.clo))
+
+! LaTeX Error: File `definitelymissingpackage.sty' not found.
+
+Type X to quit or <RETURN> to proceed,
+or enter new name. (Default extension: sty)
+
+Enter file name: 
+./document.tex:3: Emergency stop.
+<read *> 
+         
+l.3 \begin
+          {document}^^M
+./document.tex:3:  ==> Fatal error occurred, no output PDF file produced!
+Transcript written on document.log.
+Latexmk: Getting log file 'document.log'
+Latexmk: Examining 'document.fls'
+Latexmk: Examining 'document.log'
+Latexmk: Errors, so I did not complete making targets
+Collected error summary (may duplicate other messages):
+  pdflatex: Command for 'pdflatex' gave return code 1
+      Refer to 'document.log' and/or above output for details
+
+Latexmk: Missing input file 'definitelymissingpackage.sty' message in .log file:
+  ! LaTeX Error: File `definitelymissingpackage.sty' not found.
+Latexmk: Using bibtex to make bibliography file(s).
+Latexmk: Sometimes, the -f option can be used to get latexmk
+  to try to force complete processing.
+  But normally, you will need to correct the file(s) that caused the
+  error, and then rerun latexmk.
+  In some cases, it is best to clean out generated files before rerunning
+  latexmk after you've corrected the files.

--- a/spec/fixtures/latexmk_noisy_multi.txt
+++ b/spec/fixtures/latexmk_noisy_multi.txt
@@ -1,0 +1,71 @@
+Rc files read:
+  NONE
+Latexmk: This is Latexmk, John Collins, 15 June 2025. Version 4.87.
+No existing .aux file, so I'll make a simple one, and require run of *latex.
+Latexmk: applying rule 'pdflatex'...
+Rule 'pdflatex':  Reasons for rerun
+Category 'other':
+  Rerun of 'pdflatex' forced or previously required:
+    Reason or flag: 'Initial setup'
+
+------------
+Run number 1 of rule 'pdflatex'
+------------
+------------
+Running 'pdflatex -file-line-error -interaction=nonstopmode  -interaction=nonstopmode -synctex=1 -recorder  "document.tex"'
+------------
+This is pdfTeX, Version 3.141592653-2.6-1.40.27 (TeX Live 2025/nixos.org) (preloaded format=pdflatex)
+ restricted \write18 enabled.
+entering extended mode
+(./document.tex
+LaTeX2e <2025-11-01>
+L3 programming layer <2026-01-19>
+
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/
+base/article.cls
+Document Class: article 2025/01/22 v1.4n Standard LaTeX document class
+
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/
+base/size10.clo))
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/
+l3backend/l3backend-pdftex.def) (./document.aux)
+./document.tex:4: Undefined control sequence.
+l.4 \badcommand
+               {still bad}
+./document.tex:5: Undefined control sequence.
+l.5 Another undefined: \alsobad
+                               
+./document.tex:6: Undefined control sequence.
+l.6 ...and many other things including \zzznotreal
+                                                   that goes way past usual ...
+
+./document.tex:8: Missing $ inserted.
+<inserted text> 
+                $
+l.8 \end{document}
+                  
+[1{/nix/store/kah5ryh4bhdxk1w6zd0s0kz4ma5x9zy3-texlive-2025-r77567-env/share/te
+xmf-var/fonts/map/pdftex/updmap/pdftex.map}] (./document.aux) )
+(see the transcript file for additional information)</nix/store/pg73xqpq7cc8bd6
+g6agrzjv2c166pwrn-texlive-2025-r77567-env/fonts/type1/public/amsfonts/cm/cmmi10
+.pfb></nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/fonts
+/type1/public/amsfonts/cm/cmr10.pfb>
+Output written on document.pdf (1 page, 28216 bytes).
+SyncTeX written on document.synctex.gz.
+Transcript written on document.log.
+Latexmk: Getting log file 'document.log'
+Latexmk: Examining 'document.fls'
+Latexmk: Examining 'document.log'
+Latexmk: Log file says output to 'document.pdf'
+Latexmk: Errors, so I did not complete making targets
+Collected error summary (may duplicate other messages):
+  pdflatex: Command for 'pdflatex' gave return code 1
+      Refer to 'document.log' and/or above output for details
+
+Latexmk: Using bibtex to make bibliography file(s).
+Latexmk: Sometimes, the -f option can be used to get latexmk
+  to try to force complete processing.
+  But normally, you will need to correct the file(s) that caused the
+  error, and then rerun latexmk.
+  In some cases, it is best to clean out generated files before rerunning
+  latexmk after you've corrected the files.

--- a/spec/fixtures/latexmk_positive.txt
+++ b/spec/fixtures/latexmk_positive.txt
@@ -1,0 +1,47 @@
+Rc files read:
+  NONE
+Latexmk: This is Latexmk, John Collins, 15 June 2025. Version 4.87.
+No existing .aux file, so I'll make a simple one, and require run of *latex.
+Latexmk: applying rule 'pdflatex'...
+Rule 'pdflatex':  Reasons for rerun
+Category 'other':
+  Rerun of 'pdflatex' forced or previously required:
+    Reason or flag: 'Initial setup'
+
+------------
+Run number 1 of rule 'pdflatex'
+------------
+------------
+Running 'pdflatex -file-line-error -interaction=nonstopmode  -interaction=nonstopmode -synctex=1 -recorder  "document.tex"'
+------------
+This is pdfTeX, Version 3.141592653-2.6-1.40.27 (TeX Live 2025/nixos.org) (preloaded format=pdflatex)
+ restricted \write18 enabled.
+entering extended mode
+(./document.tex
+LaTeX2e <2025-11-01>
+L3 programming layer <2026-01-19>
+
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/
+base/article.cls
+Document Class: article 2025/01/22 v1.4n Standard LaTeX document class
+
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/
+base/size10.clo))
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/
+l3backend/l3backend-pdftex.def) (./document.aux) [1{/nix/store/kah5ryh4bhdxk1w6
+zd0s0kz4ma5x9zy3-texlive-2025-r77567-env/share/texmf-var/fonts/map/pdftex/updma
+p/pdftex.map}] (./document.aux) )</nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-t
+exlive-2025-r77567-env/fonts/type1/public/amsfonts/cm/cmr10.pfb></nix/store/pg7
+3xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/fonts/type1/public/amsfon
+ts/cm/cmr12.pfb></nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r7756
+7-env/fonts/type1/public/amsfonts/cm/cmr17.pfb>
+Output written on document.pdf (1 page, 31715 bytes).
+SyncTeX written on document.synctex.gz.
+Transcript written on document.log.
+Latexmk: Getting log file 'document.log'
+Latexmk: Examining 'document.fls'
+Latexmk: Examining 'document.log'
+Latexmk: Log file says output to 'document.pdf'
+Latexmk: All targets (document.pdf) are up-to-date
+
+Latexmk: Using bibtex to make bibliography file(s).

--- a/spec/fixtures/latexmk_undefined_cs.txt
+++ b/spec/fixtures/latexmk_undefined_cs.txt
@@ -1,0 +1,58 @@
+Rc files read:
+  NONE
+Latexmk: This is Latexmk, John Collins, 15 June 2025. Version 4.87.
+No existing .aux file, so I'll make a simple one, and require run of *latex.
+Latexmk: applying rule 'pdflatex'...
+Rule 'pdflatex':  Reasons for rerun
+Category 'other':
+  Rerun of 'pdflatex' forced or previously required:
+    Reason or flag: 'Initial setup'
+
+------------
+Run number 1 of rule 'pdflatex'
+------------
+------------
+Running 'pdflatex -file-line-error -interaction=nonstopmode  -interaction=nonstopmode -synctex=1 -recorder  "document.tex"'
+------------
+This is pdfTeX, Version 3.141592653-2.6-1.40.27 (TeX Live 2025/nixos.org) (preloaded format=pdflatex)
+ restricted \write18 enabled.
+entering extended mode
+(./document.tex
+LaTeX2e <2025-11-01>
+L3 programming layer <2026-01-19>
+
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/
+base/article.cls
+Document Class: article 2025/01/22 v1.4n Standard LaTeX document class
+
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/
+base/size10.clo))
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/
+l3backend/l3backend-pdftex.def) (./document.aux)
+./document.tex:4: Undefined control sequence.
+l.4 \badcommand
+               
+[1{/nix/store/kah5ryh4bhdxk1w6zd0s0kz4ma5x9zy3-texlive-2025-r77567-env/share/te
+xmf-var/fonts/map/pdftex/updmap/pdftex.map}] (./document.aux) )
+(see the transcript file for additional information)</nix/store/pg73xqpq7cc8bd6
+g6agrzjv2c166pwrn-texlive-2025-r77567-env/fonts/type1/public/amsfonts/cm/cmr10.
+pfb>
+Output written on document.pdf (1 page, 11938 bytes).
+SyncTeX written on document.synctex.gz.
+Transcript written on document.log.
+Latexmk: Getting log file 'document.log'
+Latexmk: Examining 'document.fls'
+Latexmk: Examining 'document.log'
+Latexmk: Log file says output to 'document.pdf'
+Latexmk: Errors, so I did not complete making targets
+Collected error summary (may duplicate other messages):
+  pdflatex: Command for 'pdflatex' gave return code 1
+      Refer to 'document.log' and/or above output for details
+
+Latexmk: Using bibtex to make bibliography file(s).
+Latexmk: Sometimes, the -f option can be used to get latexmk
+  to try to force complete processing.
+  But normally, you will need to correct the file(s) that caused the
+  error, and then rerun latexmk.
+  In some cases, it is best to clean out generated files before rerunning
+  latexmk after you've corrected the files.

--- a/spec/presets_spec.lua
+++ b/spec/presets_spec.lua
@@ -133,6 +133,124 @@ describe('presets', function()
       assert.is_true(presets.latex.open)
     end)
 
+    it('summarizes file-line-error format from output', function()
+      local output = table.concat({
+        './document.tex:10: Undefined control sequence.',
+        'l.10 \\badcommand',
+        'Collected error summary (may duplicate other messages):',
+        "  pdflatex: Command for 'pdflatex' gave return code 256",
+      }, '\n')
+      local result = { code = 12, stdout = output, stderr = '', output = output }
+      assert.are.equal(
+        'document.tex:10: Undefined control sequence.',
+        presets.latex.failure_summary(result, tex_ctx)
+      )
+    end)
+
+    it('summarizes file-line-error format with spaces in the path', function()
+      local output = './my docs/document.tex:10: Undefined control sequence.'
+      local result = { code = 12, stdout = output, stderr = '', output = output }
+      assert.are.equal(
+        'document.tex:10: Undefined control sequence.',
+        presets.latex.failure_summary(result, tex_ctx)
+      )
+    end)
+
+    it('prefers ! LaTeX Error over later cascading file-line errors', function()
+      local output = table.concat({
+        "! LaTeX Error: File `enumitem.sty' not found.",
+        './document.tex:3: Emergency stop.',
+        './document.tex:3:  ==> Fatal error occurred, no output PDF file produced!',
+        "  pdflatex: Command for 'pdflatex' gave return code 1",
+      }, '\n')
+      local result = { code = 12, stdout = output, stderr = '', output = output }
+      assert.are.equal(
+        "LaTeX Error: File `enumitem.sty' not found.",
+        presets.latex.failure_summary(result, tex_ctx)
+      )
+    end)
+
+    it('skips ==> continuation lines in both formats', function()
+      local output = table.concat({
+        './document.tex:3:  ==> Fatal error occurred',
+        '!  ==> Fatal error occurred, no output PDF file produced!',
+        '! Emergency stop.',
+      }, '\n')
+      local result = { code = 12, stdout = output, stderr = '', output = output }
+      assert.are.equal('Emergency stop.', presets.latex.failure_summary(result, tex_ctx))
+    end)
+
+    it('falls back to the first ! line when there is no file-line error', function()
+      local output = table.concat({
+        'Runaway argument?',
+        '! File ended while scanning use of \\@fileswith@ptions.',
+        '! Emergency stop.',
+        '!  ==> Fatal error occurred, no output PDF file produced!',
+      }, '\n')
+      local result = { code = 12, stdout = output, stderr = '', output = output }
+      assert.are.equal(
+        'File ended while scanning use of \\@fileswith@ptions.',
+        presets.latex.failure_summary(result, tex_ctx)
+      )
+    end)
+
+    it('returns nil for boilerplate-only output', function()
+      local output = table.concat({
+        'Latexmk: Errors, so I did not complete making targets',
+        'Collected error summary (may duplicate other messages):',
+        "  pdflatex: Command for 'pdflatex' gave return code 1",
+      }, '\n')
+      local result = { code = 12, stdout = output, stderr = '', output = output }
+      assert.is_nil(presets.latex.failure_summary(result, tex_ctx))
+    end)
+
+    it('returns nil for successful fixture output', function()
+      local output = helpers.read_fixture('latexmk_positive.txt')
+      local result = { code = 0, stdout = output, stderr = '', output = output }
+      assert.is_nil(presets.latex.failure_summary(result, tex_ctx))
+    end)
+
+    it('returns nil for empty output', function()
+      local result = { code = 12, stdout = '', stderr = '', output = '' }
+      assert.is_nil(presets.latex.failure_summary(result, tex_ctx))
+    end)
+
+    it('summarizes undefined control sequence fixture output', function()
+      local output = helpers.read_fixture('latexmk_undefined_cs.txt')
+      local result = { code = 12, stdout = output, stderr = '', output = output }
+      assert.are.equal(
+        'document.tex:4: Undefined control sequence.',
+        presets.latex.failure_summary(result, tex_ctx)
+      )
+    end)
+
+    it('summarizes missing package fixture output', function()
+      local output = helpers.read_fixture('latexmk_missing_pkg.txt')
+      local result = { code = 12, stdout = output, stderr = '', output = output }
+      assert.are.equal(
+        "LaTeX Error: File `definitelymissingpackage.sty' not found.",
+        presets.latex.failure_summary(result, tex_ctx)
+      )
+    end)
+
+    it('summarizes noisy multi-error fixture output', function()
+      local output = helpers.read_fixture('latexmk_noisy_multi.txt')
+      local result = { code = 12, stdout = output, stderr = '', output = output }
+      assert.are.equal(
+        'document.tex:4: Undefined control sequence.',
+        presets.latex.failure_summary(result, tex_ctx)
+      )
+    end)
+
+    it('summarizes emergency stop fixture output', function()
+      local output = helpers.read_fixture('latexmk_emergency_stop.txt')
+      local result = { code = 12, stdout = output, stderr = '', output = output }
+      assert.are.equal(
+        'File ended while scanning use of \\@fileswith@ptions.',
+        presets.latex.failure_summary(result, tex_ctx)
+      )
+    end)
+
     it('parses file-line-error format from output', function()
       local output = table.concat({
         './document.tex:10: Undefined control sequence.',


### PR DESCRIPTION
## Problem

Latexmk failures often end in boilerplate or cascading `Emergency stop.` lines, so preview.nvim's built-in LaTeX preset can surface a misleading failure notification. The preset also lacked fixture-backed coverage for the real failure shapes audited in #88.

## Solution

Add a `latex` preset `failure_summary` that walks `result.output` in order, returns the first non-`==>` `file:line:` or `!` error, and otherwise falls back to the compiler's generic message. Add fixture-backed and adversarial preset tests covering success, boilerplate-only logs, missing packages, noisy cascades, emergency-stop fallback, and paths with spaces.