### PR TITLE
feat(pdflatex): summarize actionable failures

### DIFF
--- a/lua/preview/presets.lua
+++ b/lua/preview/presets.lua
@@ -66,6 +66,54 @@ local function summarize_latexmk(output)
   end
 end
 
+---@param msg string?
+---@return string?
+local function normalize_pdflatex_message(msg)
+  if type(msg) ~= 'string' then
+    return nil
+  end
+  msg = msg:gsub('%s+', ' '):gsub('^%s+', ''):gsub('%s+$', '')
+  if msg == '' then
+    return nil
+  end
+  return msg
+end
+
+---@param msg string?
+---@return boolean
+local function is_pdflatex_noise(msg)
+  msg = normalize_pdflatex_message(msg)
+  if not msg then
+    return true
+  end
+  return msg == 'Emergency stop.'
+    or msg:match('^==>%s*Fatal error occurred, no output PDF file produced!?$') ~= nil
+end
+
+---@param output string
+---@return string?
+local function summarize_pdflatex(output)
+  for line in output:gmatch('[^\r\n]+') do
+    local msg = normalize_pdflatex_message(line:match('^!%s+(LaTeX Error: .+)$'))
+    if msg then
+      return msg
+    end
+  end
+  for line in output:gmatch('[^\r\n]+') do
+    local _, _, msg = line:match('^%.?/?(.+%.tex):(%d+):%s*(.+)$')
+    msg = normalize_pdflatex_message(msg)
+    if msg and not is_pdflatex_noise(msg) then
+      return msg
+    end
+  end
+  for line in output:gmatch('[^\r\n]+') do
+    local msg = normalize_pdflatex_message(line:match('^!%s+(.+)$'))
+    if msg and not is_pdflatex_noise(msg) then
+      return msg
+    end
+  end
+end
+
 ---@param output string
 ---@return preview.Diagnostic[]
 local function parse_pandoc(output)
@@ -239,11 +287,17 @@ M.pdflatex = {
   args = function(ctx)
     return { '-interaction=nonstopmode', '-file-line-error', '-synctex=1', ctx.file }
   end,
+  env = {
+    max_print_line = '10000',
+  },
   output = function(ctx)
     return (ctx.file:gsub('%.tex$', '.pdf'))
   end,
   error_parser = function(output)
     return parse_latexmk(output)
+  end,
+  failure_summary = function(result)
+    return summarize_pdflatex(result.output or '')
   end,
   clean = function(ctx)
     local base = ctx.file:gsub('%.tex$', '')

--- a/spec/fixtures/pdflatex_emergency_only.txt
+++ b/spec/fixtures/pdflatex_emergency_only.txt
@@ -1,0 +1,12 @@
+This is pdfTeX, Version 3.141592653-2.6-1.40.27 (TeX Live 2025/nixos.org) (preloaded format=pdflatex)
+ restricted \write18 enabled.
+entering extended mode
+(./empty.tex
+LaTeX2e <2025-11-01>
+L3 programming layer <2026-01-19>
+)
+! Emergency stop.
+<*> empty.tex
+             
+!  ==> Fatal error occurred, no output PDF file produced!
+Transcript written on empty.log.

--- a/spec/fixtures/pdflatex_file_not_found.txt
+++ b/spec/fixtures/pdflatex_file_not_found.txt
@@ -1,0 +1,30 @@
+This is pdfTeX, Version 3.141592653-2.6-1.40.27 (TeX Live 2025/nixos.org) (preloaded format=pdflatex)
+ restricted \write18 enabled.
+entering extended mode
+(./file_not_found.tex
+LaTeX2e <2025-11-01>
+L3 programming layer <2026-01-19>
+
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/
+base/article.cls
+Document Class: article 2025/01/22 v1.4n Standard LaTeX document class
+
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/
+base/size10.clo))
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/
+l3backend/l3backend-pdftex.def)
+No file file_not_found.aux.
+
+! LaTeX Error: File `nonexistent_file_xyz.tex' not found.
+
+Type X to quit or <RETURN> to proceed,
+or enter new name. (Default extension: tex)
+
+Enter file name: 
+./file_not_found.tex:3: Emergency stop.
+<read *> 
+         
+l.3 \input{nonexistent_file_xyz}
+                                ^^M
+./file_not_found.tex:3:  ==> Fatal error occurred, no output PDF file produced!
+Transcript written on file_not_found.log.

--- a/spec/fixtures/pdflatex_long_message.txt
+++ b/spec/fixtures/pdflatex_long_message.txt
@@ -1,0 +1,23 @@
+This is pdfTeX, Version 3.141592653-2.6-1.40.27 (TeX Live 2025/nixos.org) (preloaded format=pdflatex)
+ restricted \write18 enabled.
+entering extended mode
+(./long_message.tex
+LaTeX2e <2025-11-01>
+L3 programming layer <2026-01-19>
+
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/
+base/article.cls
+Document Class: article 2025/01/22 v1.4n Standard LaTeX document class
+
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/
+base/size10.clo))
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/
+l3backend/l3backend-pdftex.def)
+No file long_message.aux.
+./long_message.tex:3: Undefined control sequence.
+l.3 ...atwillgetwrappedacrossmultiplelinesofoutput
+                                                  
+(./long_message.aux) )
+(see the transcript file for additional information)
+No pages of output.
+Transcript written on long_message.log.

--- a/spec/fixtures/pdflatex_missing_brace.txt
+++ b/spec/fixtures/pdflatex_missing_brace.txt
@@ -1,0 +1,29 @@
+This is pdfTeX, Version 3.141592653-2.6-1.40.27 (TeX Live 2025/nixos.org) (preloaded format=pdflatex)
+ restricted \write18 enabled.
+entering extended mode
+(./missing_brace.tex
+LaTeX2e <2025-11-01>
+L3 programming layer <2026-01-19>
+
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/
+base/article.cls
+Document Class: article 2025/01/22 v1.4n Standard LaTeX document class
+
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/
+base/size10.clo))
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/
+l3backend/l3backend-pdftex.def)
+No file missing_brace.aux.
+)
+Runaway argument?
+{Missing closing brace. \end {document} 
+! File ended while scanning use of \textbf .
+<inserted text> 
+                \par 
+<*> missing_brace.tex
+                     
+! Emergency stop.
+<*> missing_brace.tex
+                     
+!  ==> Fatal error occurred, no output PDF file produced!
+Transcript written on missing_brace.log.

--- a/spec/fixtures/pdflatex_missing_doc_env.txt
+++ b/spec/fixtures/pdflatex_missing_doc_env.txt
@@ -1,0 +1,28 @@
+This is pdfTeX, Version 3.141592653-2.6-1.40.27 (TeX Live 2025/nixos.org) (preloaded format=pdflatex)
+ restricted \write18 enabled.
+entering extended mode
+(./missing_doc_env.tex
+LaTeX2e <2025-11-01>
+L3 programming layer <2026-01-19>
+
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/
+base/article.cls
+Document Class: article 2025/01/22 v1.4n Standard LaTeX document class
+
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/
+base/size10.clo))
+
+./missing_doc_env.tex:2: LaTeX Error: Missing \begin{document}.
+
+See the LaTeX manual or LaTeX Companion for explanation.
+Type  H <return>  for immediate help.
+ ...                                              
+                                                  
+l.2 H
+     ello with no document environment.
+)
+! Emergency stop.
+<*> missing_doc_env.tex
+                       
+!  ==> Fatal error occurred, no output PDF file produced!
+Transcript written on missing_doc_env.log.

--- a/spec/fixtures/pdflatex_missing_dollar.txt
+++ b/spec/fixtures/pdflatex_missing_dollar.txt
@@ -1,0 +1,35 @@
+This is pdfTeX, Version 3.141592653-2.6-1.40.27 (TeX Live 2025/nixos.org) (preloaded format=pdflatex)
+ restricted \write18 enabled.
+entering extended mode
+(./missing_dollar.tex
+LaTeX2e <2025-11-01>
+L3 programming layer <2026-01-19>
+
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/
+base/article.cls
+Document Class: article 2025/01/22 v1.4n Standard LaTeX document class
+
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/
+base/size10.clo))
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/
+l3backend/l3backend-pdftex.def)
+No file missing_dollar.aux.
+./missing_dollar.tex:3: Missing $ inserted.
+<inserted text> 
+                $
+l.3 This will trigger a math-mode error: \alpha
+                                                is bad outside of math.
+./missing_dollar.tex:4: Missing $ inserted.
+<inserted text> 
+                $
+l.4 \end{document}
+                  
+[1{/nix/store/kah5ryh4bhdxk1w6zd0s0kz4ma5x9zy3-texlive-2025-r77567-env/share/te
+xmf-var/fonts/map/pdftex/updmap/pdftex.map}] (./missing_dollar.aux) )
+(see the transcript file for additional information)</nix/store/pg73xqpq7cc8bd6
+g6agrzjv2c166pwrn-texlive-2025-r77567-env/fonts/type1/public/amsfonts/cm/cmmi10
+.pfb></nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/fonts
+/type1/public/amsfonts/cm/cmr10.pfb>
+Output written on missing_dollar.pdf (1 page, 25124 bytes).
+SyncTeX written on missing_dollar.synctex.gz.
+Transcript written on missing_dollar.log.

--- a/spec/fixtures/pdflatex_missing_package.txt
+++ b/spec/fixtures/pdflatex_missing_package.txt
@@ -1,0 +1,28 @@
+This is pdfTeX, Version 3.141592653-2.6-1.40.27 (TeX Live 2025/nixos.org) (preloaded format=pdflatex)
+ restricted \write18 enabled.
+entering extended mode
+(./missing_package.tex
+LaTeX2e <2025-11-01>
+L3 programming layer <2026-01-19>
+
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/
+base/article.cls
+Document Class: article 2025/01/22 v1.4n Standard LaTeX document class
+
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/
+base/size10.clo))
+
+! LaTeX Error: File `definitelymissingpackage.sty' not found.
+
+Type X to quit or <RETURN> to proceed,
+or enter new name. (Default extension: sty)
+
+Enter file name: 
+./missing_package.tex:3: Emergency stop.
+<read *> 
+         
+l.3 \begin
+          {document}^^M
+./missing_package.tex:3:  ==> Fatal error occurred, no output PDF file produced
+!
+Transcript written on missing_package.log.

--- a/spec/fixtures/pdflatex_syntax_only.txt
+++ b/spec/fixtures/pdflatex_syntax_only.txt
@@ -1,0 +1,34 @@
+This is pdfTeX, Version 3.141592653-2.6-1.40.27 (TeX Live 2025/nixos.org) (preloaded format=pdflatex)
+ restricted \write18 enabled.
+entering extended mode
+(./syntax_only.tex
+LaTeX2e <2025-11-01>
+L3 programming layer <2026-01-19>
+
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/
+base/article.cls
+Document Class: article 2025/01/22 v1.4n Standard LaTeX document class
+
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/
+base/size10.clo))
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/
+l3backend/l3backend-pdftex.def)
+No file syntax_only.aux.
+
+./syntax_only.tex:3: LaTeX Error: \begin{document} ended by \end{itemize}.
+
+See the LaTeX manual or LaTeX Companion for explanation.
+Type  H <return>  for immediate help.
+ ...                                              
+                                                  
+l.3 \end{itemize}
+                 
+./syntax_only.tex:3: Extra \endgroup.
+\end  ...end#1\endcsname \@checkend {#1}\endgroup 
+                                                  \UseHook {env/#1/after}\if...
+l.3 \end{itemize}
+                 
+(./syntax_only.aux) )
+(see the transcript file for additional information)
+No pages of output.
+Transcript written on syntax_only.log.

--- a/spec/fixtures/pdflatex_undefined_cs_full.txt
+++ b/spec/fixtures/pdflatex_undefined_cs_full.txt
@@ -1,0 +1,27 @@
+This is pdfTeX, Version 3.141592653-2.6-1.40.27 (TeX Live 2025/nixos.org) (preloaded format=pdflatex)
+ restricted \write18 enabled.
+entering extended mode
+(./undefined_cs.tex
+LaTeX2e <2025-11-01>
+L3 programming layer <2026-01-19>
+
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/
+base/article.cls
+Document Class: article 2025/01/22 v1.4n Standard LaTeX document class
+
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/
+base/size10.clo))
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/
+l3backend/l3backend-pdftex.def)
+No file undefined_cs.aux.
+./undefined_cs.tex:4: Undefined control sequence.
+l.4 \badcommand
+               
+[1{/nix/store/kah5ryh4bhdxk1w6zd0s0kz4ma5x9zy3-texlive-2025-r77567-env/share/te
+xmf-var/fonts/map/pdftex/updmap/pdftex.map}] (./undefined_cs.aux) )
+(see the transcript file for additional information)</nix/store/pg73xqpq7cc8bd6
+g6agrzjv2c166pwrn-texlive-2025-r77567-env/fonts/type1/public/amsfonts/cm/cmr10.
+pfb>
+Output written on undefined_cs.pdf (1 page, 15297 bytes).
+SyncTeX written on undefined_cs.synctex.gz.
+Transcript written on undefined_cs.log.

--- a/spec/fixtures/pdflatex_valid.txt
+++ b/spec/fixtures/pdflatex_valid.txt
@@ -1,0 +1,23 @@
+This is pdfTeX, Version 3.141592653-2.6-1.40.27 (TeX Live 2025/nixos.org) (preloaded format=pdflatex)
+ restricted \write18 enabled.
+entering extended mode
+(./valid.tex
+LaTeX2e <2025-11-01>
+L3 programming layer <2026-01-19>
+
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/
+base/article.cls
+Document Class: article 2025/01/22 v1.4n Standard LaTeX document class
+
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/
+base/size10.clo))
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/
+l3backend/l3backend-pdftex.def)
+No file valid.aux.
+[1{/nix/store/kah5ryh4bhdxk1w6zd0s0kz4ma5x9zy3-texlive-2025-r77567-env/share/te
+xmf-var/fonts/map/pdftex/updmap/pdftex.map}] (./valid.aux) )</nix/store/pg73xqp
+q7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/fonts/type1/public/amsfonts/c
+m/cmr10.pfb>
+Output written on valid.pdf (1 page, 16158 bytes).
+SyncTeX written on valid.synctex.gz.
+Transcript written on valid.log.

--- a/spec/fixtures/pdflatex_wrapped_error_unwrapped.txt
+++ b/spec/fixtures/pdflatex_wrapped_error_unwrapped.txt
@@ -1,0 +1,17 @@
+This is pdfTeX, Version 3.141592653-2.6-1.40.27 (TeX Live 2025/nixos.org) (preloaded format=pdflatex)
+ restricted \write18 enabled.
+entering extended mode
+(./wrapped_error.tex
+LaTeX2e <2025-11-01>
+L3 programming layer <2026-01-19>
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/base/article.cls
+Document Class: article 2025/01/22 v1.4n Standard LaTeX document class
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/base/size10.clo)) (/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/l3backend/l3backend-pdftex.def)
+No file wrapped_error.aux.
+./wrapped_error.tex:3: This is an intentionally extremely long error message designed to make pdflatex wrap the output onto multiple lines for testing purposes.
+l.3 ...t onto multiple lines for testing purposes}
+                                                  
+(./wrapped_error.aux) )
+(see the transcript file for additional information)
+No pages of output.
+Transcript written on wrapped_error.log.

--- a/spec/fixtures/pdflatex_wrapped_latex_error_unwrapped.txt
+++ b/spec/fixtures/pdflatex_wrapped_latex_error_unwrapped.txt
@@ -1,0 +1,23 @@
+This is pdfTeX, Version 3.141592653-2.6-1.40.27 (TeX Live 2025/nixos.org) (preloaded format=pdflatex)
+ restricted \write18 enabled.
+entering extended mode
+(./wrapped_latex_error.tex
+LaTeX2e <2025-11-01>
+L3 programming layer <2026-01-19>
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/base/article.cls
+Document Class: article 2025/01/22 v1.4n Standard LaTeX document class
+(/nix/store/pg73xqpq7cc8bd6g6agrzjv2c166pwrn-texlive-2025-r77567-env/tex/latex/base/size10.clo))
+
+! LaTeX Error: File `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.sty' not found.
+
+Type X to quit or <RETURN> to proceed,
+or enter new name. (Default extension: sty)
+
+Enter file name: 
+./wrapped_latex_error.tex:3: Emergency stop.
+<read *> 
+         
+l.3 \begin
+          {document}^^M
+./wrapped_latex_error.tex:3:  ==> Fatal error occurred, no output PDF file produced!
+Transcript written on wrapped_latex_error.log.

--- a/spec/presets_spec.lua
+++ b/spec/presets_spec.lua
@@ -308,6 +308,11 @@ describe('presets', function()
       ft = 'tex',
     }
 
+    local function pdflatex_result(path, code)
+      local output = helpers.read_fixture(path)
+      return { code = code or 1, stdout = output, stderr = '', output = output }
+    end
+
     it('has ft', function()
       assert.are.equal('tex', presets.pdflatex.ft)
     end)
@@ -346,6 +351,126 @@ describe('presets', function()
 
     it('has no reload', function()
       assert.is_nil(presets.pdflatex.reload)
+    end)
+
+    it('sets max_print_line env for stable failure summaries', function()
+      assert.are.same({ max_print_line = '10000' }, presets.pdflatex.env)
+    end)
+
+    describe('failure_summary', function()
+      it('prefers LaTeX Error for missing package fixture output', function()
+        assert.are.equal(
+          "LaTeX Error: File `definitelymissingpackage.sty' not found.",
+          presets.pdflatex.failure_summary(pdflatex_result('pdflatex_missing_package.txt'), tex_ctx)
+        )
+      end)
+
+      it('uses the first non-noise ! line for missing brace fixture output', function()
+        assert.are.equal(
+          'File ended while scanning use of \\textbf .',
+          presets.pdflatex.failure_summary(pdflatex_result('pdflatex_missing_brace.txt'), tex_ctx)
+        )
+      end)
+
+      it('uses the file-line message for undefined control sequence fixture output', function()
+        assert.are.equal(
+          'Undefined control sequence.',
+          presets.pdflatex.failure_summary(
+            pdflatex_result('pdflatex_undefined_cs_full.txt'),
+            tex_ctx
+          )
+        )
+      end)
+
+      it('uses the first non-noise file-line message for missing dollar fixture output', function()
+        assert.are.equal(
+          'Missing $ inserted.',
+          presets.pdflatex.failure_summary(pdflatex_result('pdflatex_missing_dollar.txt'), tex_ctx)
+        )
+      end)
+
+      it('prefers LaTeX Error for missing file fixture output', function()
+        assert.are.equal(
+          "LaTeX Error: File `nonexistent_file_xyz.tex' not found.",
+          presets.pdflatex.failure_summary(pdflatex_result('pdflatex_file_not_found.txt'), tex_ctx)
+        )
+      end)
+
+      it('ignores l.n continuations in long message fixture output', function()
+        assert.are.equal(
+          'Undefined control sequence.',
+          presets.pdflatex.failure_summary(pdflatex_result('pdflatex_long_message.txt'), tex_ctx)
+        )
+      end)
+
+      it('uses file-line LaTeX Error for missing document environment fixture output', function()
+        assert.are.equal(
+          'LaTeX Error: Missing \\begin{document}.',
+          presets.pdflatex.failure_summary(pdflatex_result('pdflatex_missing_doc_env.txt'), tex_ctx)
+        )
+      end)
+
+      it('uses the first file-line LaTeX Error in syntax-only fixture output', function()
+        assert.are.equal(
+          'LaTeX Error: \\begin{document} ended by \\end{itemize}.',
+          presets.pdflatex.failure_summary(pdflatex_result('pdflatex_syntax_only.txt'), tex_ctx)
+        )
+      end)
+
+      it('summarizes unwrapped long file-line message fixture output', function()
+        assert.are.equal(
+          'This is an intentionally extremely long error message designed to make pdflatex wrap the output onto multiple lines for testing purposes.',
+          presets.pdflatex.failure_summary(
+            pdflatex_result('pdflatex_wrapped_error_unwrapped.txt'),
+            tex_ctx
+          )
+        )
+      end)
+
+      it('summarizes unwrapped LaTeX Error fixture output', function()
+        assert.are.equal(
+          "LaTeX Error: File `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.sty' not found.",
+          presets.pdflatex.failure_summary(
+            pdflatex_result('pdflatex_wrapped_latex_error_unwrapped.txt'),
+            tex_ctx
+          )
+        )
+      end)
+
+      it('returns nil for emergency-only fixture output', function()
+        assert.is_nil(
+          presets.pdflatex.failure_summary(pdflatex_result('pdflatex_emergency_only.txt'), tex_ctx)
+        )
+      end)
+
+      it('returns nil for successful fixture output', function()
+        assert.is_nil(
+          presets.pdflatex.failure_summary(pdflatex_result('pdflatex_valid.txt', 0), tex_ctx)
+        )
+      end)
+
+      it('returns nil for empty output', function()
+        assert.is_nil(presets.pdflatex.failure_summary({ output = '' }, tex_ctx))
+      end)
+
+      it('does not pick Emergency stop when a later file-line error exists', function()
+        local output = table.concat({
+          './document.tex:3: Emergency stop.',
+          './document.tex:5: Missing $ inserted.',
+        }, '\n')
+        local result = { code = 1, stdout = output, stderr = '', output = output }
+        assert.are.equal('Missing $ inserted.', presets.pdflatex.failure_summary(result, tex_ctx))
+      end)
+
+      it('skips fatal continuation lines in both file-line and ! forms', function()
+        local output = table.concat({
+          './document.tex:3:  ==> Fatal error occurred, no output PDF file produced!',
+          '!  ==> Fatal error occurred, no output PDF file produced!',
+          '! Emergency stop.',
+        }, '\n')
+        local result = { code = 1, stdout = output, stderr = '', output = output }
+        assert.is_nil(presets.pdflatex.failure_summary(result, tex_ctx))
+      end)
     end)
 
     it('parses file-line-error format', function()


### PR DESCRIPTION
## Problem

`pdflatex` can wrap long error lines at 79 columns and often ends failed runs with `Emergency stop.` noise, so preview.nvim's built-in preset can surface truncated or misleading failure notifications. The preset also lacked fixture-backed coverage for the audited failure shapes in #89.

## Solution

Set `max_print_line=10000` on the preset, add a `pdflatex`-specific failure summary that prefers `! LaTeX Error`, then non-noise `file:line`, then non-noise `!` lines, and fall back to the compiler's generic message when nothing trustworthy is present. Add fixture-backed preset tests covering the audited success, fallback, noisy, wrapped, and canonical failure cases.