### PR TITLE
feat(tectonic): summarize the first real error

### DIFF
--- a/lua/preview/presets.lua
+++ b/lua/preview/presets.lua
@@ -114,6 +114,40 @@ local function summarize_pdflatex(output)
   end
 end
 
+---@param msg string?
+---@return string?
+local function normalize_tectonic_message(msg)
+  if type(msg) ~= 'string' then
+    return nil
+  end
+  msg = msg:gsub('%s+', ' '):gsub('^%s+', ''):gsub('%s+$', '')
+  if msg == '' then
+    return nil
+  end
+  local prefix, body = msg:match('^(.-:%d+:%s*)!%s*(.+)$')
+  if prefix and body then
+    return prefix .. body
+  end
+  msg = msg:gsub('^!%s*', '')
+  return msg
+end
+
+---@param result preview.Result
+---@return string?
+local function summarize_tectonic(result)
+  local stderr = result.stderr ~= '' and result.stderr or result.output or ''
+  for line in stderr:gmatch('[^\r\n]+') do
+    local msg = normalize_tectonic_message(line:match('^error:%s*(.+)$'))
+    if
+      msg
+      and msg ~= 'halted on potentially-recoverable error as specified'
+      and not msg:match('^%*%*%*%s')
+    then
+      return msg
+    end
+  end
+end
+
 ---@param output string
 ---@return preview.Diagnostic[]
 local function parse_pandoc(output)
@@ -319,6 +353,7 @@ M.tectonic = {
   error_parser = function(output)
     return parse_latexmk(output)
   end,
+  failure_summary = summarize_tectonic,
   clean = function(ctx)
     return { 'rm', '-f', (ctx.file:gsub('%.tex$', '.pdf')) }
   end,

--- a/spec/compiler_spec.lua
+++ b/spec/compiler_spec.lua
@@ -324,6 +324,49 @@ exit 12]],
       helpers.delete_buffer(bufnr)
     end)
 
+    it('uses tectonic failure summary on compile failure', function()
+      local presets = require('preview.presets')
+      local bufnr = helpers.create_buffer({ 'hello' }, 'tex')
+      vim.api.nvim_buf_set_name(bufnr, '/tmp/preview_test_fail_tectonic_summary.tex')
+      vim.bo[bufnr].modified = false
+
+      local notified = false
+      local orig = vim.notify
+      vim.notify = function(msg, level)
+        if msg == '[preview.nvim]: missing_dollar.tex:5: Missing $ inserted' then
+          notified = level == vim.log.levels.ERROR
+        end
+      end
+
+      local provider = {
+        cmd = {
+          'sh',
+          '-c',
+          [[printf '%s\n' 'error: missing_dollar.tex:5: Missing $ inserted' >&2
+printf '%s\n' 'error: halted on potentially-recoverable error as specified' >&2
+exit 1]],
+        },
+        error_parser = presets.tectonic.error_parser,
+        failure_summary = presets.tectonic.failure_summary,
+      }
+      local ctx = {
+        bufnr = bufnr,
+        file = '/tmp/preview_test_fail_tectonic_summary.tex',
+        root = '/tmp',
+        ft = 'tex',
+      }
+
+      compiler.compile(bufnr, 'tectonic', provider, ctx)
+
+      vim.wait(2000, function()
+        return process_done(bufnr)
+      end, 50)
+
+      vim.notify = orig
+      assert.is_true(notified)
+      helpers.delete_buffer(bufnr)
+    end)
+
     it('falls back when provider failure summary returns nil', function()
       local bufnr = helpers.create_buffer({ 'hello' }, 'text')
       vim.api.nvim_buf_set_name(bufnr, '/tmp/preview_test_fail_nil_summary.txt')

--- a/spec/fixtures/tectonic_empty.txt
+++ b/spec/fixtures/tectonic_empty.txt
@@ -1,0 +1,3 @@
+error: !Emergency stop
+*** (job aborted, no legal \end found)
+error: *** (job aborted, no legal \end found)

--- a/spec/fixtures/tectonic_missing_brace.txt
+++ b/spec/fixtures/tectonic_missing_brace.txt
@@ -1,2 +1,2 @@
-error: missing_dollar.tex:5: Missing $ inserted
+error: !File ended while scanning use of \textbf 
 error: halted on potentially-recoverable error as specified

--- a/spec/fixtures/tectonic_missing_image.txt
+++ b/spec/fixtures/tectonic_missing_image.txt
@@ -1,0 +1,2 @@
+error: missing_image.tex:4: Unable to load picture or PDF file 'nonexistent-image.png'
+error: halted on potentially-recoverable error as specified

--- a/spec/fixtures/tectonic_missing_input.txt
+++ b/spec/fixtures/tectonic_missing_input.txt
@@ -1,0 +1,2 @@
+error: missing_input.tex:3: ! LaTeX Error: File `nonexistent-file-xyz.tex' not found.
+error: halted on potentially-recoverable error as specified

--- a/spec/fixtures/tectonic_missing_package.txt
+++ b/spec/fixtures/tectonic_missing_package.txt
@@ -1,0 +1,2 @@
+error: missing_package.tex:3: ! LaTeX Error: File `this-package-definitely-does-not-exist.sty' not found.
+error: halted on potentially-recoverable error as specified

--- a/spec/fixtures/tectonic_multi_error.txt
+++ b/spec/fixtures/tectonic_multi_error.txt
@@ -1,2 +1,2 @@
-error: missing_dollar.tex:5: Missing $ inserted
+error: multi_error.tex:3: Undefined control sequence
 error: halted on potentially-recoverable error as specified

--- a/spec/fixtures/tectonic_valid.txt
+++ b/spec/fixtures/tectonic_valid.txt
@@ -1,0 +1,9 @@
+note: Running TeX ...
+note: Rerunning TeX because "valid.aux" changed ...
+note: Running xdvipdfmx ...
+note: downloading SHA256SUM
+note: downloading cmmi10.pfb
+note: downloading cmr10.pfb
+note: downloading cmr7.pfb
+note: Writing `valid.pdf` (7.11 KiB)
+note: Skipped writing 1 intermediate files (use --keep-intermediates to keep them)

--- a/spec/fixtures/tectonic_wrapped_long_msg.txt
+++ b/spec/fixtures/tectonic_wrapped_long_msg.txt
@@ -1,0 +1,5 @@
+error: wrapped_long_msg.tex:6: LaTeX Error: \begin{equation} on input line 4 ended by \end{equationoops}.
+
+See the LaTeX manual or LaTeX Companion for explanation.
+Type  H <return>  for immediate help
+error: halted on potentially-recoverable error as specified

--- a/spec/presets_spec.lua
+++ b/spec/presets_spec.lua
@@ -503,6 +503,11 @@ describe('presets', function()
       ft = 'tex',
     }
 
+    local function tectonic_stderr_result(path, code)
+      local stderr = helpers.read_fixture(path)
+      return { code = code or 1, stdout = '', stderr = stderr, output = stderr }
+    end
+
     it('has ft', function()
       assert.are.equal('tex', presets.tectonic.ft)
     end)
@@ -531,13 +536,103 @@ describe('presets', function()
       assert.is_nil(presets.tectonic.reload)
     end)
 
-    it('parses file-line-error format', function()
-      local output = './document.tex:5: Missing $ inserted.'
+    it('returns nil failure summary for success output', function()
+      local stdout = helpers.read_fixture('tectonic_valid.txt')
+      local result = { code = 0, stdout = stdout, stderr = '', output = stdout }
+      assert.is_nil(presets.tectonic.failure_summary(result, tex_ctx))
+    end)
+
+    it('summarizes missing dollar fixture output', function()
+      assert.are.equal(
+        'missing_dollar.tex:5: Missing $ inserted',
+        presets.tectonic.failure_summary(tectonic_stderr_result('tectonic.txt'), tex_ctx)
+      )
+    end)
+
+    it('summarizes multi-error fixture output with the first error', function()
+      assert.are.equal(
+        'multi_error.tex:3: Undefined control sequence',
+        presets.tectonic.failure_summary(
+          tectonic_stderr_result('tectonic_multi_error.txt'),
+          tex_ctx
+        )
+      )
+    end)
+
+    it('summarizes missing package fixture output', function()
+      assert.are.equal(
+        "missing_package.tex:3: LaTeX Error: File `this-package-definitely-does-not-exist.sty' not found.",
+        presets.tectonic.failure_summary(
+          tectonic_stderr_result('tectonic_missing_package.txt'),
+          tex_ctx
+        )
+      )
+    end)
+
+    it('summarizes missing input fixture output', function()
+      assert.are.equal(
+        "missing_input.tex:3: LaTeX Error: File `nonexistent-file-xyz.tex' not found.",
+        presets.tectonic.failure_summary(
+          tectonic_stderr_result('tectonic_missing_input.txt'),
+          tex_ctx
+        )
+      )
+    end)
+
+    it('summarizes missing image fixture output', function()
+      assert.are.equal(
+        "missing_image.tex:4: Unable to load picture or PDF file 'nonexistent-image.png'",
+        presets.tectonic.failure_summary(
+          tectonic_stderr_result('tectonic_missing_image.txt'),
+          tex_ctx
+        )
+      )
+    end)
+
+    it('skips continuation lines around wrapped long message fixture output', function()
+      assert.are.equal(
+        'wrapped_long_msg.tex:6: LaTeX Error: \\begin{equation} on input line 4 ended by \\end{equationoops}.',
+        presets.tectonic.failure_summary(
+          tectonic_stderr_result('tectonic_wrapped_long_msg.txt'),
+          tex_ctx
+        )
+      )
+    end)
+
+    it('strips leading ! for missing brace fixture output', function()
+      assert.are.equal(
+        'File ended while scanning use of \\textbf',
+        presets.tectonic.failure_summary(
+          tectonic_stderr_result('tectonic_missing_brace.txt'),
+          tex_ctx
+        )
+      )
+    end)
+
+    it('returns Emergency stop for empty fixture output', function()
+      assert.are.equal(
+        'Emergency stop',
+        presets.tectonic.failure_summary(tectonic_stderr_result('tectonic_empty.txt'), tex_ctx)
+      )
+    end)
+
+    it('returns nil when only the halted trailer is present', function()
+      local result = {
+        code = 1,
+        stdout = '',
+        stderr = 'error: halted on potentially-recoverable error as specified',
+        output = 'error: halted on potentially-recoverable error as specified',
+      }
+      assert.is_nil(presets.tectonic.failure_summary(result, tex_ctx))
+    end)
+
+    it('parses real tectonic error format', function()
+      local output = 'error: missing_dollar.tex:5: Missing $ inserted'
       local diagnostics = presets.tectonic.error_parser(output, tex_ctx)
       assert.are.equal(1, #diagnostics)
       assert.are.equal(4, diagnostics[1].lnum)
       assert.are.equal(0, diagnostics[1].col)
-      assert.are.equal('Missing $ inserted.', diagnostics[1].message)
+      assert.are.equal('Missing $ inserted', diagnostics[1].message)
       assert.are.equal(vim.diagnostic.severity.ERROR, diagnostics[1].severity)
     end)
 
@@ -545,7 +640,13 @@ describe('presets', function()
       local diagnostics =
         presets.tectonic.error_parser(helpers.read_fixture('tectonic.txt'), tex_ctx)
       assert.are.equal(1, #diagnostics)
-      assert.are.equal('Missing $ inserted.', diagnostics[1].message)
+      assert.are.equal('Missing $ inserted', diagnostics[1].message)
+    end)
+
+    it('returns no diagnostics for missing brace fixture output', function()
+      local diagnostics =
+        presets.tectonic.error_parser(helpers.read_fixture('tectonic_missing_brace.txt'), tex_ctx)
+      assert.are.same({}, diagnostics)
     end)
 
     it('returns empty table for clean output', function()


### PR DESCRIPTION
## Problem

The built-in `tectonic` preset still falls back to a generic failure notification or can surface the trailing `halted on potentially-recoverable error as specified` trailer instead of the first actionable stderr line. Its fixture coverage also did not reflect real captured tectonic output.

## Solution

Add a tectonic-specific `failure_summary` that scans real stderr-shaped `error:` lines, strips leading `!`, filters the halted trailer and `***` echoes, and returns the first meaningful message. Replace the hand-written fixture with captured tectonic stderr, add fixture-backed coverage for the audited failure shapes, and add a compiler test that routes the real tectonic summary through the notification path.