### PR TITLE
feat(typst): summarize the first compiler error

### DIFF
--- a/lua/preview/presets.lua
+++ b/lua/preview/presets.lua
@@ -23,6 +23,17 @@ local function parse_typst(output)
 end
 
 ---@param output string
+---@return string?
+local function summarize_typst(output)
+  local diagnostics = parse_typst(output)
+  for _, diagnostic in ipairs(diagnostics) do
+    if diagnostic.severity == vim.diagnostic.severity.ERROR then
+      return diagnostic.message
+    end
+  end
+end
+
+---@param output string
 ---@return preview.Diagnostic[]
 local function parse_latexmk(output)
   local diagnostics = {}
@@ -276,6 +287,9 @@ M.typst = {
   end,
   error_parser = function(output)
     return parse_typst(output)
+  end,
+  failure_summary = function(result)
+    return summarize_typst(result.output or '')
   end,
   clean = function(ctx)
     return { 'rm', '-f', (ctx.file:gsub('%.typ$', '.pdf')) }

--- a/spec/compiler_spec.lua
+++ b/spec/compiler_spec.lua
@@ -324,6 +324,48 @@ exit 12]],
       helpers.delete_buffer(bufnr)
     end)
 
+    it('uses typst failure summary on compile failure', function()
+      local presets = require('preview.presets')
+      local bufnr = helpers.create_buffer({ 'hello' }, 'typst')
+      vim.api.nvim_buf_set_name(bufnr, '/tmp/preview_test_fail_typst_summary.typ')
+      vim.bo[bufnr].modified = false
+
+      local notified = false
+      local orig = vim.notify
+      vim.notify = function(msg, level)
+        if msg == '[preview.nvim]: expected expression' then
+          notified = level == vim.log.levels.ERROR
+        end
+      end
+
+      local provider = {
+        cmd = {
+          'sh',
+          '-c',
+          [[printf '%s\n' 'main.typ:3:12: error: expected expression' >&2
+exit 1]],
+        },
+        error_parser = presets.typst.error_parser,
+        failure_summary = presets.typst.failure_summary,
+      }
+      local ctx = {
+        bufnr = bufnr,
+        file = '/tmp/preview_test_fail_typst_summary.typ',
+        root = '/tmp',
+        ft = 'typst',
+      }
+
+      compiler.compile(bufnr, 'typst', provider, ctx)
+
+      vim.wait(2000, function()
+        return process_done(bufnr)
+      end, 50)
+
+      vim.notify = orig
+      assert.is_true(notified)
+      helpers.delete_buffer(bufnr)
+    end)
+
     it('uses tectonic failure summary on compile failure', function()
       local presets = require('preview.presets')
       local bufnr = helpers.create_buffer({ 'hello' }, 'tex')

--- a/spec/fixtures/typst_cli_bad_flag.txt
+++ b/spec/fixtures/typst_cli_bad_flag.txt
@@ -1,0 +1,7 @@
+error: unexpected argument '--bogus-flag' found
+
+  tip: to pass '--bogus-flag' as a value, use '-- --bogus-flag'
+
+Usage: typst compile [OPTIONS] <INPUT> [OUTPUT]
+
+For more information, try '--help'.

--- a/spec/fixtures/typst_cli_no_input.txt
+++ b/spec/fixtures/typst_cli_no_input.txt
@@ -1,0 +1,1 @@
+error: input file not found (searched at does_not_exist.typ)

--- a/spec/fixtures/typst_long_message.txt
+++ b/spec/fixtures/typst_long_message.txt
@@ -1,0 +1,1 @@
+negative_long_error.typ:5:1: error: unknown variable: nonexistent_very_long_function_name_for_demonstrating_potentially_wrapping_diagnostic_output_lines

--- a/spec/fixtures/typst_missing_file.txt
+++ b/spec/fixtures/typst_missing_file.txt
@@ -1,0 +1,1 @@
+negative_missing_file.typ:3:7: error: file not found (searched at /tmp/preview.nvim/audits/typst/repro/does_not_exist.png)

--- a/spec/fixtures/typst_multiple_errors.txt
+++ b/spec/fixtures/typst_multiple_errors.txt
@@ -1,0 +1,2 @@
+negative_multiple_errors.typ:3:12: error: expected expression
+negative_multiple_errors.typ:9:9: error: unclosed delimiter

--- a/spec/fixtures/typst_panic.txt
+++ b/spec/fixtures/typst_panic.txt
@@ -1,0 +1,1 @@
+negative_panic.typ:3:1: error: panicked with: "something went terribly wrong"

--- a/spec/fixtures/typst_warning_only.txt
+++ b/spec/fixtures/typst_warning_only.txt
@@ -1,0 +1,1 @@
+positive_with_real_warning.typ:2:16: warning: unknown font family: fontthatdoesnotexistatall12345

--- a/spec/fixtures/typst_watch_first_fail.txt
+++ b/spec/fixtures/typst_watch_first_fail.txt
@@ -1,0 +1,11 @@
+watching watch_test.typ
+writing to watch_test.pdf
+
+[20:32:53] compiling ...
+
+watching watch_test.typ
+writing to watch_test.pdf
+
+[20:32:53] compiled with errors
+
+watch_test.typ:3:12: error: expected expression

--- a/spec/presets_spec.lua
+++ b/spec/presets_spec.lua
@@ -15,6 +15,11 @@ describe('presets', function()
   }
 
   describe('typst', function()
+    local function typst_result(path, code)
+      local output = helpers.read_fixture(path)
+      return { code = code or 1, stdout = '', stderr = output, output = output }
+    end
+
     it('has ft', function()
       assert.are.equal('typst', presets.typst.ft)
     end)
@@ -81,6 +86,73 @@ describe('presets', function()
       assert.are.equal(2, #diagnostics)
       assert.are.equal('unexpected token', diagnostics[1].message)
       assert.are.equal('unused variable', diagnostics[2].message)
+    end)
+
+    describe('failure_summary', function()
+      it('returns the message for a single error', function()
+        local result = {
+          code = 1,
+          stdout = '',
+          stderr = 'main.typ:3:12: error: expected expression',
+          output = 'main.typ:3:12: error: expected expression',
+        }
+        assert.are.equal('expected expression', presets.typst.failure_summary(result, ctx))
+      end)
+
+      it('returns the first error message when multiple errors are present', function()
+        assert.are.equal(
+          'expected expression',
+          presets.typst.failure_summary(typst_result('typst_multiple_errors.txt'), ctx)
+        )
+      end)
+
+      it('preserves messages containing colons and quoted text', function()
+        assert.are.equal(
+          'panicked with: "something went terribly wrong"',
+          presets.typst.failure_summary(typst_result('typst_panic.txt'), ctx)
+        )
+      end)
+
+      it('preserves file not found messages', function()
+        assert.are.equal(
+          'file not found (searched at /tmp/preview.nvim/audits/typst/repro/does_not_exist.png)',
+          presets.typst.failure_summary(typst_result('typst_missing_file.txt'), ctx)
+        )
+      end)
+
+      it('preserves long messages without truncation', function()
+        assert.are.equal(
+          'unknown variable: nonexistent_very_long_function_name_for_demonstrating_potentially_wrapping_diagnostic_output_lines',
+          presets.typst.failure_summary(typst_result('typst_long_message.txt'), ctx)
+        )
+      end)
+
+      it('skips watch-mode boilerplate and picks the first error', function()
+        local summary =
+          presets.typst.failure_summary(typst_result('typst_watch_first_fail.txt'), ctx)
+        assert.are.equal('expected expression', summary)
+        assert.is_nil(summary:find('watching ', 1, true))
+        assert.is_nil(summary:find('writing to ', 1, true))
+        assert.is_nil(summary:find('compiled with errors', 1, true))
+        assert.is_nil(summary:find('compiling ...', 1, true))
+      end)
+
+      it('returns nil for warning-only output', function()
+        assert.is_nil(presets.typst.failure_summary(typst_result('typst_warning_only.txt'), ctx))
+      end)
+
+      it('returns nil for CLI input-not-found output', function()
+        assert.is_nil(presets.typst.failure_summary(typst_result('typst_cli_no_input.txt'), ctx))
+      end)
+
+      it('returns nil for CLI argument parsing output', function()
+        assert.is_nil(presets.typst.failure_summary(typst_result('typst_cli_bad_flag.txt'), ctx))
+      end)
+
+      it('returns nil for empty output', function()
+        local result = { code = 1, stdout = '', stderr = '', output = '' }
+        assert.is_nil(presets.typst.failure_summary(result, ctx))
+      end)
     end)
 
     it('returns empty table for clean stderr', function()


### PR DESCRIPTION
## Problem

The built-in `typst` preset already parses short-format diagnostics, but failed compiles still fall back to generic failure notifications even when the first actionable error message is available. The preset also lacked fixture-backed coverage for watch-mode boilerplate, CLI fallback shapes, warning-only output, and other audited typst failure forms.

## Solution

Reuse `parse_typst` for a preset-level `failure_summary` that returns the first `ERROR` diagnostic message and falls back for warning-only or non-source-located CLI output. Add fixture-backed preset coverage for the audited typst shapes and a compiler smoke test that routes the real typst preset summary through the notification path.