### PR TITLE
feat(markdown): summarize common pandoc failures

### DIFF
--- a/lua/preview/presets.lua
+++ b/lua/preview/presets.lua
@@ -202,6 +202,110 @@ local function parse_pandoc(output)
   return diagnostics
 end
 
+---@param path string
+---@return string
+local function basename(path)
+  return path:match('([^/\\]+)$') or path
+end
+
+---@param line string?
+---@return string?
+local function trim_line(line)
+  if type(line) ~= 'string' then
+    return nil
+  end
+  line = line:match('^%s*(.-)%s*$')
+  if line == '' then
+    return nil
+  end
+  return line
+end
+
+---@param output string
+---@return string?
+local function summarize_pandoc(output)
+  local lines = vim.split(output, '\n', { plain = true, trimempty = false })
+  local i = 1
+  while i <= #lines do
+    local line = lines[i]
+    if line:match('^Error parsing YAML metadata at ".+" %(line %d+, column %d+%):$') then
+      local summary
+      for j = i + 1, #lines do
+        local next_line = trim_line(lines[j])
+        if not next_line then
+          break
+        end
+        if
+          not next_line:match('^YAML parse exception') and not next_line:match('^while parsing')
+        then
+          summary = next_line
+        end
+      end
+      if summary then
+        return 'pandoc: YAML metadata: ' .. summary
+      end
+    end
+
+    local src, msg = line:match('^Error at "(.-)" %(line %d+, column %d+%):%s*(.*)$')
+    if src then
+      msg = trim_line(msg)
+      if not msg then
+        for j = i + 1, #lines do
+          local next_line = trim_line(lines[j])
+          if next_line then
+            msg = next_line
+            break
+          end
+        end
+      end
+      if msg then
+        return 'pandoc: ' .. basename(src) .. ': ' .. msg
+      end
+    end
+
+    local filter = line:match('^Error running filter (.+):$')
+    if filter then
+      for j = i + 1, #lines do
+        local next_line = trim_line(lines[j])
+        if next_line then
+          local detail = next_line:match('^.+:(%d+:%s*.+)$') or next_line
+          return 'pandoc filter ' .. basename(filter) .. ': ' .. detail
+        end
+      end
+    end
+
+    local bibliography = line:match('^Error reading bibliography file (.+):$')
+    if bibliography then
+      for j = i + 1, #lines do
+        local next_line = trim_line(lines[j])
+        if next_line and not next_line:match('^%(') then
+          return 'pandoc: bibliography ' .. basename(bibliography) .. ': ' .. next_line
+        end
+      end
+    end
+
+    local pandoc_msg = line:match('^pandoc: (.+)$')
+    if pandoc_msg then
+      return 'pandoc: ' .. pandoc_msg
+    end
+
+    local data_file = line:match('^Could not find data file (.+)$')
+    if data_file then
+      return 'pandoc: could not find data file ' .. basename(data_file)
+    end
+
+    if
+      line:match('^Unknown output format')
+      or line:match('^Unknown option')
+      or line:match('^Argument of ')
+    then
+      return 'pandoc: ' .. line
+    end
+
+    i = i + 1
+  end
+end
+
 ---@param output string
 ---@return preview.Diagnostic[]
 local function parse_asciidoctor(output)
@@ -386,6 +490,9 @@ M.markdown = {
   end,
   error_parser = function(output)
     return parse_pandoc(output)
+  end,
+  failure_summary = function(result)
+    return summarize_pandoc(result.output or '')
   end,
   clean = function(ctx)
     return { 'rm', '-f', (ctx.file:gsub('%.md$', '.html')) }

--- a/spec/compiler_spec.lua
+++ b/spec/compiler_spec.lua
@@ -409,6 +409,48 @@ exit 1]],
       helpers.delete_buffer(bufnr)
     end)
 
+    it('uses markdown failure summary on compile failure without diagnostics', function()
+      local presets = require('preview.presets')
+      local bufnr = helpers.create_buffer({ '# hello' }, 'markdown')
+      vim.api.nvim_buf_set_name(bufnr, '/tmp/preview_test_fail_markdown_summary.md')
+      vim.bo[bufnr].modified = false
+
+      local notified = false
+      local orig = vim.notify
+      vim.notify = function(msg, level)
+        if msg == '[preview.nvim]: pandoc: Unknown option --bogus-flag.' then
+          notified = level == vim.log.levels.ERROR
+        end
+      end
+
+      local provider = vim.tbl_extend('force', {}, presets.markdown, {
+        cmd = {
+          'sh',
+          '-c',
+          [[printf '%s\n' 'Unknown option --bogus-flag.' >&2
+printf '%s\n' 'Try pandoc --help for more information.' >&2
+exit 6]],
+        },
+      })
+      local ctx = {
+        bufnr = bufnr,
+        file = '/tmp/preview_test_fail_markdown_summary.md',
+        root = '/tmp',
+        ft = 'markdown',
+        output = '/tmp/preview_test_fail_markdown_summary.html',
+      }
+
+      compiler.compile(bufnr, 'markdown', provider, ctx)
+
+      vim.wait(2000, function()
+        return process_done(bufnr)
+      end, 50)
+
+      vim.notify = orig
+      assert.is_true(notified)
+      helpers.delete_buffer(bufnr)
+    end)
+
     it('falls back when provider failure summary returns nil', function()
       local bufnr = helpers.create_buffer({ 'hello' }, 'text')
       vim.api.nvim_buf_set_name(bufnr, '/tmp/preview_test_fail_nil_summary.txt')

--- a/spec/fixtures/pandoc_bibliography.txt
+++ b/spec/fixtures/pandoc_bibliography.txt
@@ -1,0 +1,3 @@
+Error reading bibliography file repro/08_bib.bib:
+(line 3, column 3):
+unexpected 'a'

--- a/spec/fixtures/pandoc_error_at.txt
+++ b/spec/fixtures/pandoc_error_at.txt
@@ -1,0 +1,4 @@
+Error at "repro/08_bib.bib" (line 3, column 3):
+unexpected 'a'
+  author = "X"
+  ^

--- a/spec/fixtures/pandoc_filter.txt
+++ b/spec/fixtures/pandoc_filter.txt
@@ -1,0 +1,4 @@
+Error running filter repro/19_filter.lua:
+repro/19_filter.lua:2: boom from filter
+stack traceback:
+	repro/19_filter.lua:2: in function 'Pandoc'

--- a/spec/fixtures/pandoc_io_error.txt
+++ b/spec/fixtures/pandoc_io_error.txt
@@ -1,0 +1,8 @@
+pandoc: /nonexistent/file.md: withBinaryFile: does not exist (No such file or directory)
+HasCallStack backtrace:
+  collectBacktraces, called at libraries/ghc-internal/src/GHC/Internal/Exception.hs:169:13 in ghc-internal:GHC.Internal.Exception
+  toExceptionWithBacktrace, called at libraries/ghc-internal/src/GHC/Internal/IO.hs:260:11 in ghc-internal:GHC.Internal.IO
+  throwIO, called at libraries/ghc-internal/src/GHC/Internal/IO/Exception.hs:315:19 in ghc-internal:GHC.Internal.IO.Exception
+  ioException, called at libraries/ghc-internal/src/GHC/Internal/IO/Exception.hs:319:20 in ghc-internal:GHC.Internal.IO.Exception
+
+

--- a/spec/fixtures/pandoc_missing_data.txt
+++ b/spec/fixtures/pandoc_missing_data.txt
@@ -1,0 +1,1 @@
+Could not find data file /nix/store/krs6qh2x20h4yx4r23rd1vqan6cxlfmq-pandoc-3.7.0.2-data/share/ghc-9.10.3/x86_64-linux-ghc-9.10.3-7361/pandoc-3.7.0.2/data/templates/nonexistent_template.html5

--- a/spec/fixtures/pandoc_pdf_engine.txt
+++ b/spec/fixtures/pandoc_pdf_engine.txt
@@ -1,0 +1,1 @@
+Argument of --pdf-engine must be one of weasyprint, wkhtmltopdf, pagedjs-cli, prince, pdflatex, lualatex, xelatex, latexmk, tectonic, pdfroff, groff, typst, context

--- a/spec/fixtures/pandoc_unknown_opt.txt
+++ b/spec/fixtures/pandoc_unknown_opt.txt
@@ -1,0 +1,2 @@
+Unknown option --bogus-flag.
+Try pandoc --help for more information.

--- a/spec/fixtures/pandoc_unknown_output.txt
+++ b/spec/fixtures/pandoc_unknown_output.txt
@@ -1,0 +1,1 @@
+Unknown output format bogus_format

--- a/spec/fixtures/pandoc_warning_only.txt
+++ b/spec/fixtures/pandoc_warning_only.txt
@@ -1,0 +1,2 @@
+[WARNING] YAML warning (repro/18_repeated_yaml.md line 1 column 1): Duplicate key: .key2
+[WARNING] YAML warning (repro/18_repeated_yaml.md line 1 column 1): Duplicate key: .key1

--- a/spec/fixtures/pandoc_warning_then_io_error.txt
+++ b/spec/fixtures/pandoc_warning_then_io_error.txt
@@ -1,0 +1,10 @@
+[WARNING] Could not deduce format from file extension 
+  Defaulting to markdown
+pandoc: /tmp/preview.nvim/audits/markdown: withBinaryFile: inappropriate type (is a directory)
+HasCallStack backtrace:
+  collectBacktraces, called at libraries/ghc-internal/src/GHC/Internal/Exception.hs:169:13 in ghc-internal:GHC.Internal.Exception
+  toExceptionWithBacktrace, called at libraries/ghc-internal/src/GHC/Internal/IO.hs:260:11 in ghc-internal:GHC.Internal.IO
+  throwIO, called at libraries/ghc-internal/src/GHC/Internal/IO/Exception.hs:315:19 in ghc-internal:GHC.Internal.IO.Exception
+  ioException, called at libraries/ghc-internal/src/GHC/Internal/IO/Exception.hs:319:20 in ghc-internal:GHC.Internal.IO.Exception
+
+

--- a/spec/fixtures/pandoc_yaml_flow.txt
+++ b/spec/fixtures/pandoc_yaml_flow.txt
@@ -1,0 +1,4 @@
+Error parsing YAML metadata at "repro/03_yaml_flow.md" (line 1, column 1):
+YAML parse exception at line 4, column 7,
+while parsing a flow sequence:
+did not find expected ',' or ']'

--- a/spec/fixtures/pandoc_yaml_simple.txt
+++ b/spec/fixtures/pandoc_yaml_simple.txt
@@ -1,0 +1,3 @@
+Error parsing YAML metadata at "repro/02_yaml_bad.md" (line 1, column 1):
+YAML parse exception at line 1, column 10:
+mapping values are not allowed in this context

--- a/spec/presets_spec.lua
+++ b/spec/presets_spec.lua
@@ -14,6 +14,110 @@ describe('presets', function()
     ft = 'typst',
   }
 
+  local function pandoc_result(path, code)
+    local output = helpers.read_fixture(path)
+    return { code = code or 1, stdout = '', stderr = output, output = output }
+  end
+
+  local function define_pandoc_failure_summary_tests(get_provider, md_ctx)
+    describe('failure_summary', function()
+      it('produces YAML failure summary', function()
+        assert.are.equal(
+          'pandoc: YAML metadata: mapping values are not allowed in this context',
+          get_provider().failure_summary(pandoc_result('pandoc_yaml_simple.txt'), md_ctx)
+        )
+      end)
+
+      it('walks "while parsing" YAML blocks to the deepest cause', function()
+        assert.are.equal(
+          "pandoc: YAML metadata: did not find expected ',' or ']'",
+          get_provider().failure_summary(pandoc_result('pandoc_yaml_flow.txt'), md_ctx)
+        )
+      end)
+
+      it('drops HasCallStack noise from pandoc IO failures', function()
+        local summary = get_provider().failure_summary(pandoc_result('pandoc_io_error.txt'), md_ctx)
+        assert.are.equal(
+          'pandoc: /nonexistent/file.md: withBinaryFile: does not exist (No such file or directory)',
+          summary
+        )
+        assert.is_nil(summary:find('HasCallStack', 1, true))
+        assert.is_nil(summary:find('Exception.hs', 1, true))
+      end)
+
+      it('strips the nix-store path from missing template errors', function()
+        assert.are.equal(
+          'pandoc: could not find data file nonexistent_template.html5',
+          get_provider().failure_summary(pandoc_result('pandoc_missing_data.txt'), md_ctx)
+        )
+      end)
+
+      it('handles bibliography errors with filename context', function()
+        assert.are.equal(
+          "pandoc: bibliography 08_bib.bib: unexpected 'a'",
+          get_provider().failure_summary(pandoc_result('pandoc_bibliography.txt'), md_ctx)
+        )
+      end)
+
+      it('handles reader error-at failures with filename context', function()
+        assert.are.equal(
+          "pandoc: 08_bib.bib: unexpected 'a'",
+          get_provider().failure_summary(pandoc_result('pandoc_error_at.txt'), md_ctx)
+        )
+      end)
+
+      it('handles lua filter errors without stack traceback noise', function()
+        local summary = get_provider().failure_summary(pandoc_result('pandoc_filter.txt'), md_ctx)
+        assert.are.equal('pandoc filter 19_filter.lua: 2: boom from filter', summary)
+        assert.is_nil(summary:find('stack traceback', 1, true))
+      end)
+
+      it('handles unknown output formats', function()
+        assert.are.equal(
+          'pandoc: Unknown output format bogus_format',
+          get_provider().failure_summary(pandoc_result('pandoc_unknown_output.txt'), md_ctx)
+        )
+      end)
+
+      it('handles unknown options', function()
+        assert.are.equal(
+          'pandoc: Unknown option --bogus-flag.',
+          get_provider().failure_summary(pandoc_result('pandoc_unknown_opt.txt'), md_ctx)
+        )
+      end)
+
+      it('preserves long invalid pdf-engine messages', function()
+        assert.are.equal(
+          'pandoc: ' .. helpers.read_fixture('pandoc_pdf_engine.txt'),
+          get_provider().failure_summary(pandoc_result('pandoc_pdf_engine.txt'), md_ctx)
+        )
+      end)
+
+      it('ignores leading warnings before pandoc IO errors', function()
+        local summary =
+          get_provider().failure_summary(pandoc_result('pandoc_warning_then_io_error.txt'), md_ctx)
+        assert.are.equal(
+          'pandoc: /tmp/preview.nvim/audits/markdown: withBinaryFile: inappropriate type (is a directory)',
+          summary
+        )
+        assert.is_nil(summary:find('[WARNING]', 1, true))
+      end)
+
+      it('returns nil for warning-only output', function()
+        assert.is_nil(
+          get_provider().failure_summary(pandoc_result('pandoc_warning_only.txt'), md_ctx)
+        )
+      end)
+
+      it('returns nil when no shape matches', function()
+        assert.is_nil(get_provider().failure_summary({ output = '' }, md_ctx))
+        assert.is_nil(
+          get_provider().failure_summary({ output = 'random unrelated text\n' }, md_ctx)
+        )
+      end)
+    end)
+  end
+
   describe('typst', function()
     local function typst_result(path, code)
       local output = helpers.read_fixture(path)
@@ -768,6 +872,10 @@ describe('presets', function()
     it('has reload enabled for SSE', function()
       assert.is_true(presets.markdown.reload)
     end)
+
+    define_pandoc_failure_summary_tests(function()
+      return presets.markdown
+    end, md_ctx)
 
     it('parses YAML metadata errors with multiline message', function()
       local output = table.concat({


### PR DESCRIPTION
## Problem

Pandoc-backed markdown previews can fail without actionable diagnostics, leaving `:Preview` notifications too generic when compilation fails.

## Solution

Add a markdown `failure_summary` that condenses common pandoc error shapes into concise messages, and cover the real stderr forms with fixtures plus a compiler smoke test.