### PR TITLE
feat(github): summarize GFM compile failures

### DIFF
--- a/lua/preview/presets.lua
+++ b/lua/preview/presets.lua
@@ -159,6 +159,31 @@ local function summarize_tectonic(result)
   end
 end
 
+local function is_pandoc_yaml_header(line)
+  return type(line) == 'string'
+    and line:match('^Error parsing YAML metadata at ".+" %(line %d+, column %d+%):$') ~= nil
+end
+
+local function pandoc_yaml_detail(lines, start)
+  for j = start, #lines do
+    local next_line = lines[j]
+    if next_line then
+      next_line = next_line:match('^%s*(.-)%s*$')
+    end
+    if next_line == '' then
+      break
+    end
+    if
+      next_line
+      and not next_line:match('^YAML parse exception')
+      and not next_line:match('^while ')
+      and not next_line:match('^Consider ')
+    then
+      return next_line
+    end
+  end
+end
+
 ---@param output string
 ---@return preview.Diagnostic[]
 local function parse_pandoc(output)
@@ -170,11 +195,18 @@ local function parse_pandoc(output)
     local lnum, col, msg = line:match('%(line (%d+), column (%d+)%):%s*(.*)$')
     if lnum then
       if msg == '' then
-        for j = i + 1, math.min(i + 2, #lines) do
-          local next_line = lines[j]:match('^%s*(.+)$')
-          if next_line and not next_line:match('^YAML parse exception') then
-            msg = next_line
-            break
+        if is_pandoc_yaml_header(line) then
+          msg = pandoc_yaml_detail(lines, i + 1) or ''
+        else
+          for j = i + 1, #lines do
+            local next_line = lines[j] and lines[j]:match('^%s*(.-)%s*$')
+            if next_line == '' then
+              break
+            end
+            if next_line and next_line ~= '' then
+              msg = next_line
+              break
+            end
           end
         end
       end
@@ -228,19 +260,8 @@ local function summarize_pandoc(output)
   local i = 1
   while i <= #lines do
     local line = lines[i]
-    if line:match('^Error parsing YAML metadata at ".+" %(line %d+, column %d+%):$') then
-      local summary
-      for j = i + 1, #lines do
-        local next_line = trim_line(lines[j])
-        if not next_line then
-          break
-        end
-        if
-          not next_line:match('^YAML parse exception') and not next_line:match('^while parsing')
-        then
-          summary = next_line
-        end
-      end
+    if is_pandoc_yaml_header(line) then
+      local summary = pandoc_yaml_detail(lines, i + 1)
       if summary then
         return 'pandoc: YAML metadata: ' .. summary
       end
@@ -300,6 +321,55 @@ local function summarize_pandoc(output)
       or line:match('^Argument of ')
     then
       return 'pandoc: ' .. line
+    end
+
+    i = i + 1
+  end
+end
+
+---@param output string
+---@return string?
+local function summarize_github_pandoc(output)
+  local lines = vim.split(output, '\n', { plain = true, trimempty = false })
+  local i = 1
+  while i <= #lines do
+    local line = lines[i]
+    if is_pandoc_yaml_header(line) then
+      local summary = pandoc_yaml_detail(lines, i + 1)
+      if summary then
+        return 'YAML metadata: ' .. summary
+      end
+    end
+
+    local src, msg = line:match('^Error at "(.-)" %(line %d+, column %d+%):%s*(.*)$')
+    if src then
+      msg = trim_line(msg)
+      if not msg then
+        for j = i + 1, #lines do
+          local next_line = trim_line(lines[j])
+          if not next_line then
+            break
+          end
+          msg = next_line
+          break
+        end
+      end
+      if msg then
+        return basename(src) .. ': ' .. msg
+      end
+    end
+
+    local pandoc_msg = line:match('^pandoc: (.+)$')
+    if pandoc_msg then
+      return pandoc_msg
+    end
+
+    if
+      line:match('^Could not find data file ')
+      or line:match('^Unknown option')
+      or line:match('^The extension ')
+    then
+      return line
     end
 
     i = i + 1
@@ -527,6 +597,9 @@ M.github = {
   end,
   error_parser = function(output)
     return parse_pandoc(output)
+  end,
+  failure_summary = function(result)
+    return summarize_github_pandoc(result.output or '')
   end,
   clean = function(ctx)
     return { 'rm', '-f', (ctx.file:gsub('%.md$', '.html')) }

--- a/spec/compiler_spec.lua
+++ b/spec/compiler_spec.lua
@@ -451,6 +451,59 @@ exit 6]],
       helpers.delete_buffer(bufnr)
     end)
 
+    it('uses github failure summary on compile failure with diagnostics', function()
+      local presets = require('preview.presets')
+      local bufnr = helpers.create_buffer({ '# hello' }, 'markdown')
+      vim.api.nvim_buf_set_name(bufnr, '/tmp/preview_test_fail_github_summary.md')
+      vim.bo[bufnr].modified = false
+
+      local notified = false
+      local orig = vim.notify
+      vim.notify = function(msg, level)
+        if
+          msg == '[preview.nvim]: YAML metadata: mapping values are not allowed in this context'
+        then
+          notified = level == vim.log.levels.ERROR
+        end
+      end
+
+      local provider = vim.tbl_extend('force', {}, presets.github, {
+        cmd = {
+          'sh',
+          '-c',
+          [[printf '%s\n' 'Error parsing YAML metadata at "/tmp/preview_test_fail_github_summary.md" (line 1, column 1):' >&2
+printf '%s\n' 'YAML parse exception at line 2, column 6:' >&2
+printf '%s\n' 'mapping values are not allowed in this context' >&2
+exit 64]],
+        },
+      })
+      local ctx = {
+        bufnr = bufnr,
+        file = '/tmp/preview_test_fail_github_summary.md',
+        root = '/tmp',
+        ft = 'markdown',
+        output = '/tmp/preview_test_fail_github_summary.html',
+      }
+
+      compiler.compile(bufnr, 'markdown', provider, ctx)
+
+      vim.wait(2000, function()
+        return process_done(bufnr)
+      end, 50)
+
+      vim.notify = orig
+      local diagnostics = vim.diagnostic.get(bufnr)
+      assert.is_true(notified)
+      assert.are.equal(1, #diagnostics)
+      assert.are.equal('mapping values are not allowed in this context', diagnostics[1].message)
+      assert.is_truthy(
+        compiler
+          .result(bufnr).output
+          :find('mapping values are not allowed in this context', 1, true)
+      )
+      helpers.delete_buffer(bufnr)
+    end)
+
     it('falls back when provider failure summary returns nil', function()
       local bufnr = helpers.create_buffer({ 'hello' }, 'text')
       vim.api.nvim_buf_set_name(bufnr, '/tmp/preview_test_fail_nil_summary.txt')

--- a/spec/fixtures/pandoc_gfm_bad_extension.txt
+++ b/spec/fixtures/pandoc_gfm_bad_extension.txt
@@ -1,0 +1,2 @@
+The extension nonexistent_extension is not supported for gfm.
+Use --list-extensions=gfm to list supported extensions.

--- a/spec/fixtures/pandoc_gfm_input_missing.txt
+++ b/spec/fixtures/pandoc_gfm_input_missing.txt
@@ -1,0 +1,8 @@
+pandoc: /tmp/preview.nvim/audits/github/repro/__nonexistent.md: withBinaryFile: does not exist (No such file or directory)
+HasCallStack backtrace:
+  collectBacktraces, called at libraries/ghc-internal/src/GHC/Internal/Exception.hs:169:13 in ghc-internal:GHC.Internal.Exception
+  toExceptionWithBacktrace, called at libraries/ghc-internal/src/GHC/Internal/IO.hs:260:11 in ghc-internal:GHC.Internal.IO
+  throwIO, called at libraries/ghc-internal/src/GHC/Internal/IO/Exception.hs:315:19 in ghc-internal:GHC.Internal.IO.Exception
+  ioException, called at libraries/ghc-internal/src/GHC/Internal/IO/Exception.hs:319:20 in ghc-internal:GHC.Internal.IO.Exception
+
+

--- a/spec/fixtures/pandoc_gfm_template_missing.txt
+++ b/spec/fixtures/pandoc_gfm_template_missing.txt
@@ -1,0 +1,1 @@
+Could not find data file /nix/store/krs6qh2x20h4yx4r23rd1vqan6cxlfmq-pandoc-3.7.0.2-data/share/ghc-9.10.3/x86_64-linux-ghc-9.10.3-7361/pandoc-3.7.0.2/data/templates/exist.html

--- a/spec/fixtures/pandoc_gfm_unknown_option.txt
+++ b/spec/fixtures/pandoc_gfm_unknown_option.txt
@@ -1,0 +1,2 @@
+Unknown option --bad-flag-does-not-exist.
+Try pandoc --help for more information.

--- a/spec/fixtures/pandoc_gfm_yaml_alias.txt
+++ b/spec/fixtures/pandoc_gfm_yaml_alias.txt
@@ -1,0 +1,2 @@
+Error parsing YAML metadata at "repro/neg_yaml_anchor.md" (line 1, column 1):
+Unknown alias `undefined_anchor`

--- a/spec/fixtures/pandoc_gfm_yaml_block.txt
+++ b/spec/fixtures/pandoc_gfm_yaml_block.txt
@@ -1,0 +1,5 @@
+Error parsing YAML metadata at "repro/neg_yaml_block_seq.md" (line 1, column 1):
+YAML parse exception at line 3, column 1,
+while parsing a block mapping:
+did not find expected key
+Consider enclosing the entire field in 'single quotes'

--- a/spec/fixtures/pandoc_gfm_yaml_flow.txt
+++ b/spec/fixtures/pandoc_gfm_yaml_flow.txt
@@ -1,0 +1,4 @@
+Error parsing YAML metadata at "repro/neg_yaml_flow_seq.md" (line 1, column 1):
+YAML parse exception at line 3, column 0,
+while parsing a flow sequence:
+did not find expected ',' or ']'

--- a/spec/fixtures/pandoc_gfm_yaml_mapping.txt
+++ b/spec/fixtures/pandoc_gfm_yaml_mapping.txt
@@ -1,0 +1,3 @@
+Error parsing YAML metadata at "repro/neg_yaml_bad_mapping.md" (line 1, column 1):
+YAML parse exception at line 2, column 6:
+mapping values are not allowed in this context

--- a/spec/presets_spec.lua
+++ b/spec/presets_spec.lua
@@ -118,6 +118,93 @@ describe('presets', function()
     end)
   end
 
+  local function define_github_failure_summary_tests(md_ctx)
+    describe('failure_summary', function()
+      it('summarizes YAML mapping errors', function()
+        assert.are.equal(
+          'YAML metadata: mapping values are not allowed in this context',
+          presets.github.failure_summary(pandoc_result('pandoc_gfm_yaml_mapping.txt'), md_ctx)
+        )
+      end)
+
+      it('walks YAML blocks past while context', function()
+        assert.are.equal(
+          "YAML metadata: did not find expected ',' or ']'",
+          presets.github.failure_summary(pandoc_result('pandoc_gfm_yaml_flow.txt'), md_ctx)
+        )
+      end)
+
+      it('skips trailing Consider hints in YAML blocks', function()
+        assert.are.equal(
+          'YAML metadata: did not find expected key',
+          presets.github.failure_summary(pandoc_result('pandoc_gfm_yaml_block.txt'), md_ctx)
+        )
+      end)
+
+      it('summarizes YAML alias errors', function()
+        assert.are.equal(
+          'YAML metadata: Unknown alias `undefined_anchor`',
+          presets.github.failure_summary(pandoc_result('pandoc_gfm_yaml_alias.txt'), md_ctx)
+        )
+      end)
+
+      it('handles Error at failures with filename context', function()
+        local result = {
+          code = 1,
+          stdout = '',
+          stderr = 'Error at "document.md" (line 12, column 5): unexpected "}" expecting letter',
+          output = 'Error at "document.md" (line 12, column 5): unexpected "}" expecting letter',
+        }
+        assert.are.equal(
+          'document.md: unexpected "}" expecting letter',
+          presets.github.failure_summary(result, md_ctx)
+        )
+      end)
+
+      it('summarizes pandoc IO errors without HasCallStack noise', function()
+        local summary =
+          presets.github.failure_summary(pandoc_result('pandoc_gfm_input_missing.txt'), md_ctx)
+        assert.are.equal(
+          '/tmp/preview.nvim/audits/github/repro/__nonexistent.md: withBinaryFile: does not exist (No such file or directory)',
+          summary
+        )
+        assert.is_nil(summary:find('HasCallStack', 1, true))
+        assert.is_nil(summary:find('Exception.hs', 1, true))
+      end)
+
+      it('summarizes template-missing errors', function()
+        assert.are.equal(
+          helpers.read_fixture('pandoc_gfm_template_missing.txt'),
+          presets.github.failure_summary(pandoc_result('pandoc_gfm_template_missing.txt'), md_ctx)
+        )
+      end)
+
+      it('summarizes unknown option errors', function()
+        assert.are.equal(
+          'Unknown option --bad-flag-does-not-exist.',
+          presets.github.failure_summary(pandoc_result('pandoc_gfm_unknown_option.txt'), md_ctx)
+        )
+      end)
+
+      it('summarizes unsupported extension errors', function()
+        assert.are.equal(
+          'The extension nonexistent_extension is not supported for gfm.',
+          presets.github.failure_summary(pandoc_result('pandoc_gfm_bad_extension.txt'), md_ctx)
+        )
+      end)
+
+      it('returns nil for empty output', function()
+        assert.is_nil(presets.github.failure_summary({ output = '' }, md_ctx))
+      end)
+
+      it('returns nil when output matches no known pattern', function()
+        assert.is_nil(
+          presets.github.failure_summary({ output = 'random unrelated text\n' }, md_ctx)
+        )
+      end)
+    end)
+  end
+
   describe('typst', function()
     local function typst_result(path, code)
       local output = helpers.read_fixture(path)
@@ -916,7 +1003,7 @@ describe('presets', function()
     it('parses fixture output', function()
       local diagnostics = presets.markdown.error_parser(helpers.read_fixture('pandoc.txt'), md_ctx)
       assert.are.equal(1, #diagnostics)
-      assert.are.equal('while parsing a flow sequence:', diagnostics[1].message)
+      assert.are.equal("did not find expected ',' or ']'", diagnostics[1].message)
     end)
 
     it('returns empty table for clean output', function()
@@ -992,6 +1079,8 @@ describe('presets', function()
       assert.is_true(presets.github.reload)
     end)
 
+    define_github_failure_summary_tests(md_ctx)
+
     it('parses YAML metadata errors with multiline message', function()
       local output = table.concat({
         'Error parsing YAML metadata at "/tmp/test.md" (line 1, column 1):',
@@ -1020,7 +1109,14 @@ describe('presets', function()
     it('parses fixture output', function()
       local diagnostics = presets.github.error_parser(helpers.read_fixture('pandoc.txt'), md_ctx)
       assert.are.equal(1, #diagnostics)
-      assert.are.equal('while parsing a flow sequence:', diagnostics[1].message)
+      assert.are.equal("did not find expected ',' or ']'", diagnostics[1].message)
+    end)
+
+    it('parses YAML blocks past while and Consider lines', function()
+      local diagnostics =
+        presets.github.error_parser(helpers.read_fixture('pandoc_gfm_yaml_block.txt'), md_ctx)
+      assert.are.equal(1, #diagnostics)
+      assert.are.equal('did not find expected key', diagnostics[1].message)
     end)
 
     it('returns empty table for clean output', function()


### PR DESCRIPTION
## Problem

GitHub-flavored markdown previews only surface generic compile failures, and shared pandoc YAML diagnostics can report context lines instead of the real cause.

## Solution

Add a github-specific failure summary for the audited GFM pandoc failure shapes, fix shared pandoc YAML cause-line selection, and cover the new behavior with captured fixtures plus preset and compiler tests.