### PR TITLE
feat(quarto): summarize render failures

### DIFF
--- a/lua/preview/presets.lua
+++ b/lua/preview/presets.lua
@@ -449,6 +449,31 @@ local function parse_quarto(output)
   return {}
 end
 
+local QUARTO_NOISE = {
+  ['Validation of YAML front matter failed.'] = true,
+  ['Render failed due to invalid YAML.'] = true,
+  ['Error encountered when rendering files'] = true,
+}
+
+---@param result preview.Result
+---@return string?
+local function summarize_quarto(result)
+  local output = result.output or ''
+  if output == '' then
+    return nil
+  end
+  output = output:gsub('\27%[[0-9;]*m', '')
+  for line in output:gmatch('[^\r\n]+') do
+    local msg = line:match('^ERROR:%s*(.+)$')
+    if msg then
+      msg = msg:gsub('^%s*(.-)%s*$', '%1')
+      if not QUARTO_NOISE[msg] and not msg:match('^In file ') then
+        return msg
+      end
+    end
+  end
+end
+
 ---@type preview.ProviderConfig
 M.typst = {
   ft = 'typst',
@@ -690,6 +715,9 @@ M.quarto = {
   end,
   error_parser = function(output)
     return parse_quarto(output)
+  end,
+  failure_summary = function(result)
+    return summarize_quarto(result)
   end,
   clean = function(ctx)
     local base = ctx.file:gsub('%.qmd$', '')

--- a/spec/compiler_spec.lua
+++ b/spec/compiler_spec.lua
@@ -504,6 +504,60 @@ exit 64]],
       helpers.delete_buffer(bufnr)
     end)
 
+    it('uses quarto failure summary on compile failure with diagnostics', function()
+      local presets = require('preview.presets')
+      local bufnr = helpers.create_buffer({ '---', 'title: [oops', 'format: html' }, 'quarto')
+      vim.api.nvim_buf_set_name(bufnr, '/tmp/preview_test_fail_quarto_summary.qmd')
+      vim.bo[bufnr].modified = false
+
+      local notified = false
+      local orig = vim.notify
+      vim.notify = function(msg, level)
+        if
+          msg == '[preview.nvim]: YAMLException: missed comma between flow collection entries (3:1)'
+        then
+          notified = level == vim.log.levels.ERROR
+        end
+      end
+
+      local provider = vim.tbl_extend('force', {}, presets.quarto, {
+        cmd = {
+          'sh',
+          '-c',
+          [[printf '\033[91mERROR: YAMLException: missed comma between flow collection entries (3:1)\n\n 1 |\n 2 | title: [oops\n 3 | format: html\n-----^\n\nStack trace:\n    at generateError2 (file:///nix/store/example/bin/quarto.js:1:1)\033[39m' >&2
+exit 1]],
+        },
+      })
+      local ctx = {
+        bufnr = bufnr,
+        file = '/tmp/preview_test_fail_quarto_summary.qmd',
+        root = '/tmp',
+        ft = 'quarto',
+        output = '/tmp/preview_test_fail_quarto_summary.html',
+      }
+
+      compiler.compile(bufnr, 'quarto', provider, ctx)
+
+      vim.wait(2000, function()
+        return process_done(bufnr)
+      end, 50)
+
+      vim.notify = orig
+      local diagnostics = vim.diagnostic.get(bufnr)
+      assert.is_true(notified)
+      assert.are.equal(1, #diagnostics)
+      assert.are.equal(
+        'YAMLException: missed comma between flow collection entries',
+        diagnostics[1].message
+      )
+      assert.is_truthy(
+        compiler
+          .result(bufnr).output
+          :find('YAMLException: missed comma between flow collection entries', 1, true)
+      )
+      helpers.delete_buffer(bufnr)
+    end)
+
     it('falls back when provider failure summary returns nil', function()
       local bufnr = helpers.create_buffer({ 'hello' }, 'text')
       vim.api.nvim_buf_set_name(bufnr, '/tmp/preview_test_fail_nil_summary.txt')

--- a/spec/fixtures/quarto_filter_missing.txt
+++ b/spec/fixtures/quarto_filter_missing.txt
@@ -1,0 +1,19 @@
+[1mpandoc --embed-resources[22m
+  to: html
+  output-file: pandoc_filter_missing.html
+  standalone: true
+  section-divs: true
+  html-math-method: mathjax
+  wrap: none
+  default-image-extension: png
+  variables: {}
+  
+[1mmetadata[22m
+  document-css: false
+  link-citations: true
+  date-format: long
+  lang: en
+  title: Missing lua filter
+  
+[31mERROR (/nix/store/9y19yq7842p72l9nmqdbs1s3cddzld9m-quarto-1.8.26/share/filters/main.lua:3828) cannot open this-filter-does-not-exist.lua: No such file or directory
+[39m[33mWARN: Error encountered when rendering files[39m

--- a/spec/fixtures/quarto_missing_input.txt
+++ b/spec/fixtures/quarto_missing_input.txt
@@ -1,0 +1,11 @@
+[91mERROR: No valid input files passed to render
+
+Stack trace:
+    at _Command.actionHandler (file:///nix/store/9y19yq7842p72l9nmqdbs1s3cddzld9m-quarto-1.8.26/bin/quarto.js:129775:11)
+    at async _Command.execute (file:///nix/store/9y19yq7842p72l9nmqdbs1s3cddzld9m-quarto-1.8.26/bin/quarto.js:9840:7)
+    at async _Command.parseCommand (file:///nix/store/9y19yq7842p72l9nmqdbs1s3cddzld9m-quarto-1.8.26/bin/quarto.js:9717:14)
+    at async quarto (file:///nix/store/9y19yq7842p72l9nmqdbs1s3cddzld9m-quarto-1.8.26/bin/quarto.js:175538:5)
+    at async file:///nix/store/9y19yq7842p72l9nmqdbs1s3cddzld9m-quarto-1.8.26/bin/quarto.js:175566:5
+    at async file:///nix/store/9y19yq7842p72l9nmqdbs1s3cddzld9m-quarto-1.8.26/bin/quarto.js:175421:14
+    at async mainRunner (file:///nix/store/9y19yq7842p72l9nmqdbs1s3cddzld9m-quarto-1.8.26/bin/quarto.js:175423:5)
+    at async file:///nix/store/9y19yq7842p72l9nmqdbs1s3cddzld9m-quarto-1.8.26/bin/quarto.js:175559:3[39m

--- a/spec/fixtures/quarto_python_traceback.txt
+++ b/spec/fixtures/quarto_python_traceback.txt
@@ -1,0 +1,20 @@
+
+Starting python3 kernel...Done
+
+Executing 'python_engine_error.quarto_ipynb'
+  Cell 1/1: ''...
+
+An error occurred while executing the following cell:
+------------------
+1 / 0
+------------------
+
+
+[31m---------------------------------------------------------------------------[39m
+[31mZeroDivisionError[39m                         Traceback (most recent call last)
+[36mCell[39m[36m [39m[32mIn[1][39m[32m, line 1[39m
+[32m----> [39m[32m1[39m [32;43m1[39;49m[43m [49m[43m/[49m[43m [49m[32;43m0[39;49m
+
+[31mZeroDivisionError[39m: division by zero
+
+[33mWARN: Error encountered when rendering files[39m

--- a/spec/fixtures/quarto_success.txt
+++ b/spec/fixtures/quarto_success.txt
@@ -1,0 +1,19 @@
+[1mpandoc --embed-resources[22m
+  to: html
+  output-file: positive.html
+  standalone: true
+  section-divs: true
+  html-math-method: mathjax
+  wrap: none
+  default-image-extension: png
+  variables: {}
+  
+[1mmetadata[22m
+  document-css: false
+  link-citations: true
+  date-format: long
+  lang: en
+  title: Positive Path
+  
+Output created: positive.html
+

--- a/spec/fixtures/quarto_unknown_format.txt
+++ b/spec/fixtures/quarto_unknown_format.txt
@@ -1,0 +1,13 @@
+[91mERROR: Unknown format thisformatdoesnotexist
+
+Stack trace:
+    at resolveFormats (file:///nix/store/9y19yq7842p72l9nmqdbs1s3cddzld9m-quarto-1.8.26/bin/quarto.js:118044:13)
+    at async renderContexts (file:///nix/store/9y19yq7842p72l9nmqdbs1s3cddzld9m-quarto-1.8.26/bin/quarto.js:117794:20)
+    at async renderFileInternal (file:///nix/store/9y19yq7842p72l9nmqdbs1s3cddzld9m-quarto-1.8.26/bin/quarto.js:123778:16)
+    at async renderFiles (file:///nix/store/9y19yq7842p72l9nmqdbs1s3cddzld9m-quarto-1.8.26/bin/quarto.js:123695:9)
+    at async render (file:///nix/store/9y19yq7842p72l9nmqdbs1s3cddzld9m-quarto-1.8.26/bin/quarto.js:129503:19)
+    at async _Command.actionHandler (file:///nix/store/9y19yq7842p72l9nmqdbs1s3cddzld9m-quarto-1.8.26/bin/quarto.js:129745:24)
+    at async _Command.execute (file:///nix/store/9y19yq7842p72l9nmqdbs1s3cddzld9m-quarto-1.8.26/bin/quarto.js:9840:7)
+    at async _Command.parseCommand (file:///nix/store/9y19yq7842p72l9nmqdbs1s3cddzld9m-quarto-1.8.26/bin/quarto.js:9717:14)
+    at async quarto (file:///nix/store/9y19yq7842p72l9nmqdbs1s3cddzld9m-quarto-1.8.26/bin/quarto.js:175538:5)
+    at async file:///nix/store/9y19yq7842p72l9nmqdbs1s3cddzld9m-quarto-1.8.26/bin/quarto.js:175566:5[39m

--- a/spec/fixtures/quarto_yaml_validation.txt
+++ b/spec/fixtures/quarto_yaml_validation.txt
@@ -1,0 +1,9 @@
+[91mERROR: Validation of YAML front matter failed.[39m
+ERROR: In file yaml_validation.qmd
+(line 2, columns 1--6) Field "[34mtitle[39m" has empty value but it must instead be a string
+1: [34m---[39m
+2: [34mtitle:[39m
+        ~
+3: [34mformat: html[39m
+
+[91mERROR: Render failed due to invalid YAML.[39m

--- a/spec/presets_spec.lua
+++ b/spec/presets_spec.lua
@@ -1292,6 +1292,10 @@ describe('presets', function()
       output = '/tmp/document.html',
     }
 
+    local function quarto_summary(path, code)
+      return presets.quarto.failure_summary(pandoc_result(path, code), qmd_ctx)
+    end
+
     it('has ft', function()
       assert.are.equal('quarto', presets.quarto.ft)
     end)
@@ -1324,6 +1328,45 @@ describe('presets', function()
 
     it('has reload enabled for SSE', function()
       assert.is_true(presets.quarto.reload)
+    end)
+
+    describe('failure_summary', function()
+      it('summarizes YAMLException with location', function()
+        assert.are.equal(
+          'YAMLException: missed comma between flow collection entries (3:1)',
+          quarto_summary('quarto.txt')
+        )
+      end)
+
+      it('summarizes unknown render formats', function()
+        assert.are.equal(
+          'Unknown format thisformatdoesnotexist',
+          quarto_summary('quarto_unknown_format.txt')
+        )
+      end)
+
+      it('summarizes missing input files', function()
+        assert.are.equal(
+          'No valid input files passed to render',
+          quarto_summary('quarto_missing_input.txt')
+        )
+      end)
+
+      it('returns nil for YAML validation wrapper output', function()
+        assert.is_nil(quarto_summary('quarto_yaml_validation.txt'))
+      end)
+
+      it('returns nil for pandoc-routed filter errors', function()
+        assert.is_nil(quarto_summary('quarto_filter_missing.txt'))
+      end)
+
+      it('returns nil for python tracebacks', function()
+        assert.is_nil(quarto_summary('quarto_python_traceback.txt'))
+      end)
+
+      it('returns nil for success output', function()
+        assert.is_nil(quarto_summary('quarto_success.txt', 0))
+      end)
     end)
 
     it('parses fixture output', function()


### PR DESCRIPTION
## Problem

Quarto failures can bury the actionable ERROR line behind wrapper text and stack traces, leaving notifications too generic.

## Solution

Add a conservative quarto failure summary for the audited ERROR-shaped failures, and cover the success, fallback, and notification paths with captured fixtures plus preset and compiler tests.

Closes #94