### PR TITLE
feat(asciidoctor): summarize compile failures

### DIFF
--- a/lua/preview/presets.lua
+++ b/lua/preview/presets.lua
@@ -398,6 +398,33 @@ local function parse_asciidoctor(output)
   return diagnostics
 end
 
+---@param output string?
+---@return string?
+local function summarize_asciidoctor(output)
+  if type(output) ~= 'string' or output == '' then
+    return nil
+  end
+  local first_warning
+  for line in output:gmatch('[^\r\n]+') do
+    local severity, body = line:match('^asciidoctor: (%u+): (.+)$')
+    if severity == 'ERROR' or severity == 'FATAL' then
+      return body
+    end
+    if severity == 'WARNING' and not first_warning then
+      first_warning = body
+    end
+    local failed = line:match('^asciidoctor: FAILED: (.+)$')
+    if failed then
+      return failed
+    end
+    local invalid = line:match('^asciidoctor: invalid (.+)$')
+    if invalid then
+      return 'invalid ' .. invalid
+    end
+  end
+  return first_warning
+end
+
 ---@param output string
 ---@return preview.Diagnostic[]
 local function parse_mermaid(output)
@@ -645,6 +672,9 @@ M.asciidoctor = {
   end,
   error_parser = function(output)
     return parse_asciidoctor(output)
+  end,
+  failure_summary = function(result)
+    return summarize_asciidoctor(result.output)
   end,
   clean = function(ctx)
     return { 'rm', '-f', (ctx.file:gsub('%.adoc$', '.html')) }

--- a/spec/compiler_spec.lua
+++ b/spec/compiler_spec.lua
@@ -558,6 +558,56 @@ exit 1]],
       helpers.delete_buffer(bufnr)
     end)
 
+    it('uses asciidoctor failure summary when usage output precedes stderr', function()
+      local presets = require('preview.presets')
+      local bufnr = helpers.create_buffer({ '= Hello' }, 'asciidoc')
+      vim.api.nvim_buf_set_name(bufnr, '/tmp/preview_test_fail_asciidoctor_summary.adoc')
+      vim.bo[bufnr].modified = false
+
+      local notified = false
+      local orig = vim.notify
+      vim.notify = function(msg, level)
+        if msg == '[preview.nvim]: invalid option: --bogus-option' then
+          notified = level == vim.log.levels.ERROR
+        end
+      end
+
+      local provider = vim.tbl_extend('force', {}, presets.asciidoctor, {
+        cmd = {
+          'sh',
+          '-c',
+          [[printf '%s\n' 'Usage: asciidoctor [OPTION]... FILE...'
+printf '%s\n' 'Convert the AsciiDoc input FILE(s) to the backend output format (e.g., HTML 5, DocBook 5, etc.)'
+printf '%s\n' 'Unless specified otherwise, the output is written to a file whose name is derived from the input file.'
+printf '%s\n' 'Application log messages are printed to STDERR.'
+printf '%s\n' 'asciidoctor: invalid option: --bogus-option' >&2
+exit 1]],
+        },
+      })
+      local ctx = {
+        bufnr = bufnr,
+        file = '/tmp/preview_test_fail_asciidoctor_summary.adoc',
+        root = '/tmp',
+        ft = 'asciidoc',
+        output = '/tmp/preview_test_fail_asciidoctor_summary.html',
+      }
+
+      compiler.compile(bufnr, 'asciidoctor', provider, ctx)
+
+      vim.wait(2000, function()
+        return process_done(bufnr)
+      end, 50)
+
+      vim.notify = orig
+      local diagnostics = vim.diagnostic.get(bufnr)
+      assert.is_true(notified)
+      assert.are.same({}, diagnostics)
+      assert.is_truthy(
+        compiler.result(bufnr).output:find('asciidoctor: invalid option: --bogus-option', 1, true)
+      )
+      helpers.delete_buffer(bufnr)
+    end)
+
     it('falls back when provider failure summary returns nil', function()
       local bufnr = helpers.create_buffer({ 'hello' }, 'text')
       vim.api.nvim_buf_set_name(bufnr, '/tmp/preview_test_fail_nil_summary.txt')

--- a/spec/fixtures/asciidoctor_error_with_warning.txt
+++ b/spec/fixtures/asciidoctor_error_with_warning.txt
@@ -1,0 +1,2 @@
+asciidoctor: WARNING: mixed_err_warn.adoc: line 5: section title out of sequence: expected level 2, got level 3
+asciidoctor: ERROR: mixed_err_warn.adoc: line 7: include file not found: /tmp/preview.nvim/audits/asciidoctor/repro/missing.adoc

--- a/spec/fixtures/asciidoctor_failed.txt
+++ b/spec/fixtures/asciidoctor_failed.txt
@@ -1,0 +1,1 @@
+asciidoctor: FAILED: input file /tmp/nonexistent-asciidoc-input.adoc is missing

--- a/spec/fixtures/asciidoctor_invalid_option.txt
+++ b/spec/fixtures/asciidoctor_invalid_option.txt
@@ -1,0 +1,5 @@
+Usage: asciidoctor [OPTION]... FILE...
+Convert the AsciiDoc input FILE(s) to the backend output format (e.g., HTML 5, DocBook 5, etc.)
+Unless specified otherwise, the output is written to a file whose name is derived from the input file.
+Application log messages are printed to STDERR.
+asciidoctor: invalid option: --bogus-option

--- a/spec/fixtures/asciidoctor_multi_error.txt
+++ b/spec/fixtures/asciidoctor_multi_error.txt
@@ -1,0 +1,3 @@
+asciidoctor: ERROR: multiple_errors.adoc: line 3: include file not found: /tmp/preview.nvim/audits/asciidoctor/repro/missing_a.adoc
+asciidoctor: ERROR: multiple_errors.adoc: line 5: include file not found: /tmp/preview.nvim/audits/asciidoctor/repro/missing_b.adoc
+asciidoctor: ERROR: multiple_errors.adoc: line 12: dropping cells from incomplete row detected end of table

--- a/spec/fixtures/asciidoctor_trace.txt
+++ b/spec/fixtures/asciidoctor_trace.txt
@@ -1,0 +1,2 @@
+/nix/store/k847n3yr24097d9v469m2mwr2xhbw811-ruby3.4-asciidoctor-2.0.26/lib/ruby/gems/3.4.0/gems/asciidoctor-2.0.26/lib/asciidoctor/document.rb:1339:in 'Asciidoctor::Document#update_backend_attributes': asciidoctor: FAILED: missing converter for backend 'nonexistent_backend'. Processing aborted. (NotImplementedError)
+	from /nix/store/k847n3yr24097d9v469m2mwr2xhbw811-ruby3.4-asciidoctor-2.0.26/lib/ruby/gems/3.4.0/gems/asciidoctor-2.0.26/lib/asciidoctor/document.rb:477:in 'Asciidoctor::Document#initialize'

--- a/spec/fixtures/asciidoctor_warning_only.txt
+++ b/spec/fixtures/asciidoctor_warning_only.txt
@@ -1,0 +1,1 @@
+asciidoctor: WARNING: warning_only.adoc: line 8: section title out of sequence: expected level 2, got level 3

--- a/spec/presets_spec.lua
+++ b/spec/presets_spec.lua
@@ -1165,6 +1165,65 @@ describe('presets', function()
       assert.is_true(presets.asciidoctor.reload)
     end)
 
+    describe('failure_summary', function()
+      it('summarizes a single ERROR line', function()
+        local output = 'asciidoctor: ERROR: doc.adoc: line 5: include file not found: /tmp/a.adoc\n'
+        assert.are.equal(
+          'doc.adoc: line 5: include file not found: /tmp/a.adoc',
+          presets.asciidoctor.failure_summary({ output = output }, adoc_ctx)
+        )
+      end)
+
+      it('skips WARNING when an ERROR is present', function()
+        local output = helpers.read_fixture('asciidoctor_error_with_warning.txt')
+        assert.are.equal(
+          'mixed_err_warn.adoc: line 7: include file not found: /tmp/preview.nvim/audits/asciidoctor/repro/missing.adoc',
+          presets.asciidoctor.failure_summary({ output = output }, adoc_ctx)
+        )
+      end)
+
+      it('returns the first ERROR when many are present', function()
+        local output = helpers.read_fixture('asciidoctor_multi_error.txt')
+        assert.are.equal(
+          'multiple_errors.adoc: line 3: include file not found: /tmp/preview.nvim/audits/asciidoctor/repro/missing_a.adoc',
+          presets.asciidoctor.failure_summary({ output = output }, adoc_ctx)
+        )
+      end)
+
+      it('summarizes FAILED form', function()
+        local output = helpers.read_fixture('asciidoctor_failed.txt')
+        assert.are.equal(
+          'input file /tmp/nonexistent-asciidoc-input.adoc is missing',
+          presets.asciidoctor.failure_summary({ output = output }, adoc_ctx)
+        )
+      end)
+
+      it('summarizes invalid option even when usage precedes it', function()
+        local output = helpers.read_fixture('asciidoctor_invalid_option.txt')
+        assert.are.equal(
+          'invalid option: --bogus-option',
+          presets.asciidoctor.failure_summary({ output = output }, adoc_ctx)
+        )
+      end)
+
+      it('falls back to nil for Ruby stack traces without anchored asciidoctor lines', function()
+        local output = helpers.read_fixture('asciidoctor_trace.txt')
+        assert.is_nil(presets.asciidoctor.failure_summary({ output = output }, adoc_ctx))
+      end)
+
+      it('falls back to nil on empty output', function()
+        assert.is_nil(presets.asciidoctor.failure_summary({ output = '' }, adoc_ctx))
+      end)
+
+      it('summarizes WARNING when it is the only available severity', function()
+        local output = helpers.read_fixture('asciidoctor_warning_only.txt')
+        assert.are.equal(
+          'warning_only.adoc: line 8: section title out of sequence: expected level 2, got level 3',
+          presets.asciidoctor.failure_summary({ output = output }, adoc_ctx)
+        )
+      end)
+    end)
+
     it('parses error messages', function()
       local output =
         'asciidoctor: ERROR: document.adoc: line 8: invalid part, must have at least one section'


### PR DESCRIPTION
## Problem

Asciidoctor failures can surface as ERROR, FAILED, or invalid-option lines, while the existing parser only covers diagnostics-shaped entries and leaves some notifications generic.

## Solution

Add an asciidoctor failure summary for the audited stderr shapes, and cover the warning, FAILED, invalid-option, fallback, and compiler notification paths with fixtures plus tests.

Closes #95