### PR TITLE
feat(plantuml): summarize compile failures (#96)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,3 @@
-<!--
-  Thank you for contributing to Neovim!
-  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
-  for our PR guidelines.
--->
-
 ## Problem
 
 ## Solution

--- a/lua/preview/presets.lua
+++ b/lua/preview/presets.lua
@@ -425,6 +425,30 @@ local function summarize_asciidoctor(output)
   return first_warning
 end
 
+---@param line string?
+---@return integer?
+local function plantuml_error_line(line)
+  local lnum = type(line) == 'string' and line:match('^Error line (%d+) in file:')
+  return lnum and tonumber(lnum) or nil
+end
+
+---@param output string?
+---@return string?
+local function summarize_plantuml(output)
+  if type(output) ~= 'string' or output == '' then
+    return nil
+  end
+  for line in output:gmatch('[^\r\n]+') do
+    local lnum = plantuml_error_line(line)
+    if lnum then
+      return string.format('plantuml: error on line %d (see :Preview output)', lnum)
+    end
+    if line == 'No diagram found' then
+      return 'plantuml: no diagram found (see :Preview output)'
+    end
+  end
+end
+
 ---@param output string
 ---@return preview.Diagnostic[]
 local function parse_mermaid(output)
@@ -696,10 +720,10 @@ M.plantuml = {
   error_parser = function(output)
     local diagnostics = {}
     for line in output:gmatch('[^\r\n]+') do
-      local lnum = line:match('^Error line (%d+) in file:')
+      local lnum = plantuml_error_line(line)
       if lnum then
         table.insert(diagnostics, {
-          lnum = tonumber(lnum) - 1,
+          lnum = lnum - 1,
           col = 0,
           message = line,
           severity = vim.diagnostic.severity.ERROR,
@@ -707,6 +731,9 @@ M.plantuml = {
       end
     end
     return diagnostics
+  end,
+  failure_summary = function(result)
+    return summarize_plantuml(result.output)
   end,
   clean = function(ctx)
     return { 'rm', '-f', (ctx.file:gsub('%.puml$', '.svg')) }

--- a/spec/fixtures/plantuml-checkonly.txt
+++ b/spec/fixtures/plantuml-checkonly.txt
@@ -1,0 +1,1 @@
+Some diagram description contains errors

--- a/spec/fixtures/plantuml-error-line.txt
+++ b/spec/fixtures/plantuml-error-line.txt
@@ -1,0 +1,2 @@
+Error line 3 in file: syntax-error.puml
+Some diagram description contains errors

--- a/spec/fixtures/plantuml-no-diagram.txt
+++ b/spec/fixtures/plantuml-no-diagram.txt
@@ -1,0 +1,2 @@
+Warning: no image in no-startuml.puml
+No diagram found

--- a/spec/fixtures/plantuml-verbose.txt
+++ b/spec/fixtures/plantuml-verbose.txt
@@ -1,0 +1,24 @@
+(0.187 - 248 Mo) 237 Mo - SecurityProfile LEGACY
+(0.212 - 248 Mo) 236 Mo - PlantUML Version 1.2026.2
+(0.213 - 248 Mo) 236 Mo - GraphicsEnvironment.isHeadless() true
+(0.214 - 248 Mo) 236 Mo - Forcing resource load on OpenJdk
+(0.288 - 248 Mo) 235 Mo - Found 1 files
+(0.303 - 248 Mo) 235 Mo - Using several threads: 12
+(0.312 - 248 Mo) 235 Mo - Working on syntax-error.puml
+(0.353 - 248 Mo) 234 Mo - Using charset UTF-8
+(0.361 - 248 Mo) 234 Mo - Reading from syntax-error.puml
+(0.431 - 248 Mo) 232 Mo - Setting current dir: /tmp/preview.nvim/audits/plantuml/repro/.
+(0.431 - 248 Mo) 232 Mo - Setting current dir: /tmp/preview.nvim/audits/plantuml/repro
+(0.603 - 248 Mo) 226 Mo - Trying to load style plantuml.skin
+(0.605 - 248 Mo) 226 Mo - Current dir is /tmp/preview.nvim/audits/plantuml/repro so trying /tmp/preview.nvim/audits/plantuml/repro/plantuml.skin
+(0.607 - 248 Mo) 226 Mo - File not found : 
+(0.611 - 248 Mo) 226 Mo - ... but plantuml.skin found inside the .jar
+(0.839 - 248 Mo) 235 Mo - Compilation duration 337
+(0.839 - 248 Mo) 235 Mo - Reading file: syntax-error.puml
+(0.841 - 248 Mo) 235 Mo - We are going to put data in [0]
+(0.842 - 248 Mo) 235 Mo - Creating file: /tmp/preview.nvim/audits/plantuml/repro/syntax-error.svg
+(0.916 - 248 Mo) 233 Mo - Reading from COMPRESS
+(0.928 - 248 Mo) 233 Mo - Transformer=class com.sun.org.apache.xalan.internal.xsltc.trax.TransformerImpl
+(0.993 - 248 Mo) 232 Mo - Number of image(s): 1
+Error line 3 in file: syntax-error.puml
+Some diagram description contains errors

--- a/spec/presets_spec.lua
+++ b/spec/presets_spec.lua
@@ -1265,6 +1265,11 @@ describe('presets', function()
       output = '/tmp/document.svg',
     }
 
+    local function plantuml_result(path, code)
+      local output = helpers.read_fixture(path)
+      return { code = code or 1, stdout = '', stderr = output, output = output }
+    end
+
     it('has ft', function()
       assert.are.equal('plantuml', presets.plantuml.ft)
     end)
@@ -1287,6 +1292,39 @@ describe('presets', function()
 
     it('has open enabled', function()
       assert.is_true(presets.plantuml.open)
+    end)
+
+    describe('failure_summary', function()
+      it('summarizes parse errors with the failing line number', function()
+        assert.are.equal(
+          'plantuml: error on line 3 (see :Preview output)',
+          presets.plantuml.failure_summary(plantuml_result('plantuml-error-line.txt'), puml_ctx)
+        )
+      end)
+
+      it('summarizes missing diagrams', function()
+        assert.are.equal(
+          'plantuml: no diagram found (see :Preview output)',
+          presets.plantuml.failure_summary(plantuml_result('plantuml-no-diagram.txt'), puml_ctx)
+        )
+      end)
+
+      it('ignores generic failures without a line number or no-diagram marker', function()
+        assert.is_nil(
+          presets.plantuml.failure_summary(plantuml_result('plantuml-checkonly.txt'), puml_ctx)
+        )
+      end)
+
+      it('finds the error line after verbose logging noise', function()
+        assert.are.equal(
+          'plantuml: error on line 3 (see :Preview output)',
+          presets.plantuml.failure_summary(plantuml_result('plantuml-verbose.txt'), puml_ctx)
+        )
+      end)
+
+      it('returns nil for empty output', function()
+        assert.is_nil(presets.plantuml.failure_summary({ output = '' }, puml_ctx))
+      end)
     end)
 
     it('parses fixture output', function()


### PR DESCRIPTION
## Problem

`plantuml` failures still fall back to the generic compile notification for audited stderr shapes like line-numbered parse errors and `No diagram found`. The repository PR template also still included an inherited Neovim comment banner that does not apply here.

## Solution

Add a `plantuml` `failure_summary` for those audited stderr shapes, reuse the same line extractor in the diagnostic parser, cover the behavior with fixture-backed preset tests, and remove the stale comment block from `.github/pull_request_template.md`. Closes #96.