### PR TITLE
feat(mermaid): summarize compile failures (#97)

### DIFF
--- a/lua/preview/presets.lua
+++ b/lua/preview/presets.lua
@@ -449,19 +449,60 @@ local function summarize_plantuml(output)
   end
 end
 
+---@param line string?
+---@return integer?
+local function mermaid_parse_error_line(line)
+  if type(line) ~= 'string' then
+    return nil
+  end
+  local lnum = line:match('^Error: Parse error on line (%d+):$')
+    or line:match('^Parse error on line (%d+):$')
+  return lnum and tonumber(lnum) or nil
+end
+
+---@param line string?
+---@return string?
+local function mermaid_expectation(line)
+  if type(line) ~= 'string' then
+    return nil
+  end
+  return line:match("^%s*(Expecting '.-got '.+')%s*$")
+end
+
+---@param output string?
+---@return string?
+local function summarize_mermaid(output)
+  if type(output) ~= 'string' or output == '' then
+    return nil
+  end
+  local lnum
+  local msg
+  for line in output:gmatch('[^\r\n]+') do
+    lnum = lnum or mermaid_parse_error_line(line)
+    msg = msg or mermaid_expectation(line)
+  end
+  if lnum and msg then
+    return string.format('Parse error on line %d: %s', lnum, msg)
+  end
+end
+
 ---@param output string
 ---@return preview.Diagnostic[]
 local function parse_mermaid(output)
-  local lnum = output:match('Parse error on line (%d+)')
+  local lnum
+  local msg
+  for line in output:gmatch('[^\r\n]+') do
+    lnum = lnum or mermaid_parse_error_line(line)
+    msg = msg or mermaid_expectation(line)
+  end
   if not lnum then
     return {}
   end
-  local msg = output:match('(Expecting .+)') or 'parse error'
   return {
     {
-      lnum = tonumber(lnum) - 1,
+      lnum = lnum - 1,
       col = 0,
-      message = msg,
+      message = msg or 'parse error',
       severity = vim.diagnostic.severity.ERROR,
     },
   }
@@ -753,6 +794,9 @@ M.mermaid = {
   end,
   error_parser = function(output)
     return parse_mermaid(output)
+  end,
+  failure_summary = function(result)
+    return summarize_mermaid(result.output)
   end,
   clean = function(ctx)
     return { 'rm', '-f', (ctx.file:gsub('%.mmd$', '.svg')) }

--- a/spec/fixtures/mermaid_deep_error.txt
+++ b/spec/fixtures/mermaid_deep_error.txt
@@ -1,8 +1,8 @@
 
-Error: Parse error on line 3:
-...[Start] --> B    B -> 1
-----------------------^
-Expecting 'SEMI', 'NEWLINE', 'EOF', 'AMP', 'START_LINK', 'LINK', 'LINK_ID', got 'MINUS'
+Error: Parse error on line 14:
+...Result]    K -- 1
+--------------------^
+Expecting 'LINK', 'UNICODE_TEXT', 'EDGE_TEXT', got '1'
 Parser.parseError (/nix/store/vqjy0drbsz4dmkh16myi45lwx0phcldv-mermaid-cli-11.12.0/lib/node_modules/@mermaid-js/mermaid-cli/node_modules/mermaid/dist/mermaid.js:91236:28)
     at #evaluate (file:///nix/store/vqjy0drbsz4dmkh16myi45lwx0phcldv-mermaid-cli-11.12.0/lib/node_modules/@mermaid-js/mermaid-cli/node_modules/puppeteer-core/lib/esm/puppeteer/cdp/ExecutionContext.js:388:19)
     at async ExecutionContext.evaluate (file:///nix/store/vqjy0drbsz4dmkh16myi45lwx0phcldv-mermaid-cli-11.12.0/lib/node_modules/@mermaid-js/mermaid-cli/node_modules/puppeteer-core/lib/esm/puppeteer/cdp/ExecutionContext.js:275:16)

--- a/spec/fixtures/mermaid_poison_excerpt.txt
+++ b/spec/fixtures/mermaid_poison_excerpt.txt
@@ -1,8 +1,9 @@
+error (ignored): SQLite database '/home/barrett/.cache/nix/eval-cache-v6/d699fe8c706dfb850b2c25fc6a981b745f4cb4235380b15aec843aa82004b38c.sqlite' is busy
 
 Error: Parse error on line 3:
-...[Start] --> B    B -> 1
+...--> Expecting    B 1
 ----------------------^
-Expecting 'SEMI', 'NEWLINE', 'EOF', 'AMP', 'START_LINK', 'LINK', 'LINK_ID', got 'MINUS'
+Expecting 'SEMI', 'NEWLINE', 'EOF', 'AMP', 'START_LINK', 'LINK', 'LINK_ID', got 'NUM'
 Parser.parseError (/nix/store/vqjy0drbsz4dmkh16myi45lwx0phcldv-mermaid-cli-11.12.0/lib/node_modules/@mermaid-js/mermaid-cli/node_modules/mermaid/dist/mermaid.js:91236:28)
     at #evaluate (file:///nix/store/vqjy0drbsz4dmkh16myi45lwx0phcldv-mermaid-cli-11.12.0/lib/node_modules/@mermaid-js/mermaid-cli/node_modules/puppeteer-core/lib/esm/puppeteer/cdp/ExecutionContext.js:388:19)
     at async ExecutionContext.evaluate (file:///nix/store/vqjy0drbsz4dmkh16myi45lwx0phcldv-mermaid-cli-11.12.0/lib/node_modules/@mermaid-js/mermaid-cli/node_modules/puppeteer-core/lib/esm/puppeteer/cdp/ExecutionContext.js:275:16)

--- a/spec/fixtures/mermaid_unknown_diagram.txt
+++ b/spec/fixtures/mermaid_unknown_diagram.txt
@@ -1,9 +1,10 @@
+error (ignored): SQLite database '/home/barrett/.cache/nix/eval-cache-v6/d699fe8c706dfb850b2c25fc6a981b745f4cb4235380b15aec843aa82004b38c.sqlite' is busy
 
-Error: Parse error on line 3:
-...[Start] --> B    B -> 1
-----------------------^
-Expecting 'SEMI', 'NEWLINE', 'EOF', 'AMP', 'START_LINK', 'LINK', 'LINK_ID', got 'MINUS'
-Parser.parseError (/nix/store/vqjy0drbsz4dmkh16myi45lwx0phcldv-mermaid-cli-11.12.0/lib/node_modules/@mermaid-js/mermaid-cli/node_modules/mermaid/dist/mermaid.js:91236:28)
+UnknownDiagramError: No diagram type detected matching given configuration for text: notADiagramType
+    foo --> bar
+
+detectType (/nix/store/vqjy0drbsz4dmkh16myi45lwx0phcldv-mermaid-cli-11.12.0/lib/node_modules/@mermaid-js/mermaid-cli/node_modules/mermaid/dist/mermaid.js:20437:15)
+    at $eval ($eval at renderMermaid (file:///nix/store/vqjy0drbsz4dmkh16myi45lwx0phcldv-mermaid-cli-11.12.0/lib/node_modules/@mermaid-js/mermaid-cli/src/index.js:266:33), <anonymous>:48:45)
     at #evaluate (file:///nix/store/vqjy0drbsz4dmkh16myi45lwx0phcldv-mermaid-cli-11.12.0/lib/node_modules/@mermaid-js/mermaid-cli/node_modules/puppeteer-core/lib/esm/puppeteer/cdp/ExecutionContext.js:388:19)
     at async ExecutionContext.evaluate (file:///nix/store/vqjy0drbsz4dmkh16myi45lwx0phcldv-mermaid-cli-11.12.0/lib/node_modules/@mermaid-js/mermaid-cli/node_modules/puppeteer-core/lib/esm/puppeteer/cdp/ExecutionContext.js:275:16)
     at async IsolatedWorld.evaluate (file:///nix/store/vqjy0drbsz4dmkh16myi45lwx0phcldv-mermaid-cli-11.12.0/lib/node_modules/@mermaid-js/mermaid-cli/node_modules/puppeteer-core/lib/esm/puppeteer/cdp/IsolatedWorld.js:97:16)
@@ -13,5 +14,4 @@ Parser.parseError (/nix/store/vqjy0drbsz4dmkh16myi45lwx0phcldv-mermaid-cli-11.12
     at async CdpFrame.$eval (file:///nix/store/vqjy0drbsz4dmkh16myi45lwx0phcldv-mermaid-cli-11.12.0/lib/node_modules/@mermaid-js/mermaid-cli/node_modules/puppeteer-core/lib/esm/puppeteer/api/Frame.js:450:20)
     at async CdpPage.$eval (file:///nix/store/vqjy0drbsz4dmkh16myi45lwx0phcldv-mermaid-cli-11.12.0/lib/node_modules/@mermaid-js/mermaid-cli/node_modules/puppeteer-core/lib/esm/puppeteer/api/Page.js:450:20)
     at async renderMermaid (file:///nix/store/vqjy0drbsz4dmkh16myi45lwx0phcldv-mermaid-cli-11.12.0/lib/node_modules/@mermaid-js/mermaid-cli/src/index.js:266:22)
-    at fromText (/nix/store/vqjy0drbsz4dmkh16myi45lwx0phcldv-mermaid-cli-11.12.0/lib/node_modules/@mermaid-js/mermaid-cli/node_modules/mermaid/dist/mermaid.js:153955:21)
 

--- a/spec/presets_spec.lua
+++ b/spec/presets_spec.lua
@@ -1345,6 +1345,11 @@ describe('presets', function()
       output = '/tmp/document.svg',
     }
 
+    local function mermaid_result(path, code)
+      local output = helpers.read_fixture(path)
+      return { code = code or 1, stdout = '', stderr = output, output = output }
+    end
+
     it('has ft', function()
       assert.are.equal('mermaid', presets.mermaid.ft)
     end)
@@ -1372,11 +1377,59 @@ describe('presets', function()
       assert.is_true(presets.mermaid.open)
     end)
 
+    describe('failure_summary', function()
+      it('returns failure summary for canonical parse error', function()
+        assert.are.equal(
+          "Parse error on line 3: Expecting 'SEMI', 'NEWLINE', 'EOF', 'AMP', 'START_LINK', 'LINK', 'LINK_ID', got 'MINUS'",
+          presets.mermaid.failure_summary(mermaid_result('mermaid.txt'), mmd_ctx)
+        )
+      end)
+
+      it('returns failure summary with line number greater than nine', function()
+        assert.are.equal(
+          "Parse error on line 14: Expecting 'LINK', 'UNICODE_TEXT', 'EDGE_TEXT', got '1'",
+          presets.mermaid.failure_summary(mermaid_result('mermaid_deep_error.txt'), mmd_ctx)
+        )
+      end)
+
+      it('rejects bare Expecting in source excerpts', function()
+        assert.are.equal(
+          "Parse error on line 3: Expecting 'SEMI', 'NEWLINE', 'EOF', 'AMP', 'START_LINK', 'LINK', 'LINK_ID', got 'NUM'",
+          presets.mermaid.failure_summary(mermaid_result('mermaid_poison_excerpt.txt'), mmd_ctx)
+        )
+      end)
+
+      it('returns nil for UnknownDiagramError output', function()
+        assert.is_nil(
+          presets.mermaid.failure_summary(mermaid_result('mermaid_unknown_diagram.txt'), mmd_ctx)
+        )
+      end)
+
+      it('returns nil for CLI errors outside mermaid parse failures', function()
+        assert.is_nil(
+          presets.mermaid.failure_summary(
+            { output = 'Input file "x.mmd" doesn\'t exist\n' },
+            mmd_ctx
+          )
+        )
+      end)
+
+      it('returns nil for empty and success output', function()
+        assert.is_nil(presets.mermaid.failure_summary({ output = '' }, mmd_ctx))
+        assert.is_nil(
+          presets.mermaid.failure_summary({ output = 'Generating single mermaid chart\n' }, mmd_ctx)
+        )
+      end)
+    end)
+
     it('parses fixture output', function()
       local diagnostics = presets.mermaid.error_parser(helpers.read_fixture('mermaid.txt'), mmd_ctx)
       assert.are.equal(1, #diagnostics)
       assert.are.equal(2, diagnostics[1].lnum)
-      assert.is_truthy(diagnostics[1].message:find('Expecting', 1, true))
+      assert.are.equal(
+        "Expecting 'SEMI', 'NEWLINE', 'EOF', 'AMP', 'START_LINK', 'LINK', 'LINK_ID', got 'MINUS'",
+        diagnostics[1].message
+      )
     end)
   end)
 


### PR DESCRIPTION
## Problem

`mermaid` compile failures still fall back to generic notifications for real parse errors, and the old parser can greedily capture source excerpts or stack traces instead of the actual `Expecting ... got ...` payload from current `mmdc` output.

## Solution

Add a `mermaid` `failure_summary` that only summarizes trusted parse-error shapes, tighten the diagnostic parser to use the same anchored matches, and update the fixtures and specs to cover noisy parse output and conservative fallback cases. Closes #97.