### PR TITLE
docs(vimdoc): reorganize preset documentation

### DIFF
--- a/doc/preview.nvim.txt
+++ b/doc/preview.nvim.txt
@@ -21,18 +21,12 @@ CONTENTS                                                    *preview-contents*
   3. Install ............................................... |preview-install|
   4. Configuration .......................................... |preview-config|
   5. Presets ............................................... |preview-presets|
-     - Preset notes ................................... |preview-preset-notes|
-     - LaTeX presets ................................. |preview-latex-presets|
-     - Pandoc presets ............................... |preview-pandoc-presets|
-     - Pandoc math rendering .................................. |preview-math|
-     - Diagram presets ............................. |preview-diagram-presets|
-     - HTML presets ................................... |preview-html-presets|
   6. Commands ............................................. |preview-commands|
   7. Lua API ................................................... |preview-api|
   8. Events ................................................. |preview-events|
   9. Health ................................................. |preview-health|
-  10. FAQ ..................................................... |preview-faq|
-  11. SyncTeX ............................................. |preview-synctex|
+  10. FAQ ...................................................... |preview-faq|
+  11. SyncTeX .............................................. |preview-synctex|
 
 ==============================================================================
 REQUIREMENTS                                            *preview-requirements*
@@ -197,49 +191,48 @@ individual fields by passing a table instead: >lua
     vim.g.preview = { typst = true, latex = true, github = true }
 <
 
-  `typst`              typst compile → PDF
-  `latex`              latexmk -pdf → PDF (with clean support)
-  `pdflatex`           pdflatex → PDF (single pass, no latexmk)
-  `tectonic`           tectonic → PDF (Rust-based LaTeX engine)
-  `markdown`           pandoc → HTML (standalone, KaTeX math)
-  `github`             pandoc → HTML (GitHub-styled, `-f gfm`, KaTeX math)
-  `asciidoctor`        asciidoctor → HTML (AsciiDoc with SSE reload)
-  `plantuml`           plantuml → SVG (UML diagrams, `.puml`)
-  `mermaid`            mmdc → SVG (Mermaid diagrams, `.mmd`)
-  `quarto`             quarto render → HTML (scientific publishing)
-
 Exact preset defaults and parser behavior live in `lua/preview/presets.lua`.
 This section covers stable user-facing defaults and common
 `failure_summary` behavior. See |preview.ProviderConfig|.
 
-Preset notes ~
-                                                        *preview-preset-notes*
+The following presets are bundled:
 
-  `typst`    `.typ` → PDF. Reload uses `typst watch`.
-             Summary shows the first error diagnostic.
+  `typst`      Compiles `.typ` files to PDF. Reload uses `typst watch`.
+               Summary shows the first error diagnostic.
 
-LaTeX presets ~
-                                                       *preview-latex-presets*
+  `latex`      Compiles `.tex` files to PDF with `latexmk -pdf`.
+               `:Preview clean` runs `latexmk -c`. Summary prefers the
+               first actionable file-line or `!` error.
 
-  `latex`    `latexmk -pdf`; `:Preview clean` runs `latexmk -c`.
-             Summary prefers the first actionable file-line or `!` error.
+  `pdflatex`   Compiles `.tex` files to PDF with single-pass `pdflatex`
+               and `-file-line-error`. Summary skips common fatal noise
+               and prefers the first real LaTeX error.
 
-  `pdflatex` Single-pass `pdflatex` with `-file-line-error`.
-             Summary skips common fatal noise and prefers the first real
-             LaTeX error.
+  `tectonic`   Compiles `.tex` files to PDF with `tectonic`.
+               Summary uses `error:` lines and ignores the generic halt
+               line.
 
-  `tectonic` `tectonic`-based `.tex` → PDF.
-             Summary uses `error:` lines and ignores the generic halt line.
+  `markdown`   Renders standalone HTML with pandoc and reload support.
+               Summary shortens common YAML, parse, filter, and
+               bibliography errors. See |preview-math|.
 
-Pandoc presets ~
-                                                      *preview-pandoc-presets*
+  `github`     Renders GitHub-style HTML from pandoc `-f gfm`.
+               Uses the bundled template when available. Summary matches
+               `markdown`. See |preview-math|.
 
-  `markdown` Pandoc standalone HTML with reload support.
-             Summary shortens common YAML, parse, filter, and bibliography
-             errors.
+  `asciidoctor` Renders `.adoc` files to HTML with reload support.
+                Summary shows the first actionable asciidoctor error.
 
-  `github`   Pandoc HTML from `-f gfm`, with the bundled GitHub-style
-             template when available. Summary matches `markdown`.
+  `plantuml`   Renders `.puml` files to SVG.
+               Summary covers line-based parse errors and
+               "no diagram found".
+
+  `mermaid`    Renders `.mmd` files to SVG via `mmdc`.
+               Summary only covers Mermaid parse errors, not generic CLI
+               failures.
+
+  `quarto`     Renders `.qmd` files to HTML with `--embed-resources`
+               and reload support. Summary uses Quarto `ERROR:` lines.
 
 Pandoc math rendering ~
                                                                 *preview-math*
@@ -266,33 +259,14 @@ Self-contained output with `--embed-resources`: >lua
     }
 <
 
-This inlines external resources into the HTML. With `--katex`, compile time
-increases by about 15s per save because pandoc fetches KaTeX during
+This inlines external resources into the HTML. With `--katex`, compile
+time increases by about 15s per save because pandoc fetches KaTeX during
 compilation. Pair with `--mathml` to avoid that penalty: >lua
 
     vim.g.preview = {
       github = { extra_args = { '--embed-resources', '--mathml' } },
     }
 <
-
-Diagram presets ~
-                                                    *preview-diagram-presets*
-
-  `plantuml` `.puml` → SVG.
-             Summary covers line-based parse errors and "no diagram found".
-
-  `mermaid`  `.mmd` → SVG via `mmdc`.
-             Summary only covers Mermaid parse errors, not generic CLI
-             failures.
-
-HTML presets ~
-                                                       *preview-html-presets*
-
-  `asciidoctor` `.adoc` → HTML with reload support.
-                Summary shows the first actionable asciidoctor error.
-
-  `quarto`      `.qmd` → HTML with `--embed-resources` and reload support.
-                Summary uses Quarto `ERROR:` lines.
 
 ==============================================================================
 COMMANDS                                                    *preview-commands*

--- a/doc/preview.nvim.txt
+++ b/doc/preview.nvim.txt
@@ -19,13 +19,18 @@ CONTENTS                                                    *preview-contents*
   1. Introduction ............................................. |preview.nvim|
   2. Requirements ..................................... |preview-requirements|
   3. Install ............................................... |preview-install|
-  4. Configuration ........................................... |preview-config|
+  4. Configuration .......................................... |preview-config|
   5. Presets ............................................... |preview-presets|
-     - Math rendering ....................................... |preview-math|
+     - Preset notes ................................... |preview-preset-notes|
+     - LaTeX presets ................................. |preview-latex-presets|
+     - Pandoc presets ............................... |preview-pandoc-presets|
+     - Pandoc math rendering .................................. |preview-math|
+     - Diagram presets ............................. |preview-diagram-presets|
+     - HTML presets ................................... |preview-html-presets|
   6. Commands ............................................. |preview-commands|
   7. Lua API ................................................... |preview-api|
-  8. Events ............................................... |preview-events|
-  9. Health ............................................... |preview-health|
+  8. Events ................................................. |preview-events|
+  9. Health ................................................. |preview-health|
   10. FAQ ..................................................... |preview-faq|
   11. SyncTeX ............................................. |preview-synctex|
 
@@ -203,25 +208,56 @@ individual fields by passing a table instead: >lua
   `mermaid`            mmdc → SVG (Mermaid diagrams, `.mmd`)
   `quarto`             quarto render → HTML (scientific publishing)
 
-Math rendering (pandoc presets): ~
+Exact preset defaults and parser behavior live in `lua/preview/presets.lua`.
+This section covers stable user-facing defaults and common
+`failure_summary` behavior. See |preview.ProviderConfig|.
+
+Preset notes ~
+                                                        *preview-preset-notes*
+
+  `typst`    `.typ` → PDF. Reload uses `typst watch`.
+             Summary shows the first error diagnostic.
+
+LaTeX presets ~
+                                                       *preview-latex-presets*
+
+  `latex`    `latexmk -pdf`; `:Preview clean` runs `latexmk -c`.
+             Summary prefers the first actionable file-line or `!` error.
+
+  `pdflatex` Single-pass `pdflatex` with `-file-line-error`.
+             Summary skips common fatal noise and prefers the first real
+             LaTeX error.
+
+  `tectonic` `tectonic`-based `.tex` → PDF.
+             Summary uses `error:` lines and ignores the generic halt line.
+
+Pandoc presets ~
+                                                      *preview-pandoc-presets*
+
+  `markdown` Pandoc standalone HTML with reload support.
+             Summary shortens common YAML, parse, filter, and bibliography
+             errors.
+
+  `github`   Pandoc HTML from `-f gfm`, with the bundled GitHub-style
+             template when available. Summary matches `markdown`.
+
+Pandoc math rendering ~
                                                                 *preview-math*
 
-The `markdown` and `github` presets use `--katex` by default, which inserts a
-`<script>` tag that loads KaTeX from a CDN at view time. The browser fetches
-the assets once and caches them, so math renders instantly on subsequent
-loads. Requires internet on first view.
+The `markdown` and `github` presets use `--katex` by default, so the browser
+loads KaTeX from a CDN on first view and then caches it.
 
-For offline use, swap in `--mathml` via `extra_args`. MathML is rendered
-natively by the browser with no external dependencies: >lua
+For offline use, add `--mathml` via `extra_args`. MathML renders natively
+with no external dependencies: >lua
 
     vim.g.preview = {
       github = { extra_args = { '--mathml' } },
     }
 <
 
-Note: pandoc's math flags (`--katex`, `--mathml`, `--mathjax`) are mutually
-exclusive — last flag wins. Adding `--mathml` via `extra_args` (which is
-appended after `args`) overrides `--katex`.
+Pandoc math flags (`--katex`, `--mathml`, `--mathjax`) are mutually
+exclusive — last flag wins. Because `extra_args` is appended after `args`,
+adding `--mathml` overrides the default `--katex`.
 
 Self-contained output with `--embed-resources`: >lua
 
@@ -230,14 +266,33 @@ Self-contained output with `--embed-resources`: >lua
     }
 <
 
-This inlines all external resources into the HTML. With `--katex` this adds
-~15s of compile time per save (pandoc fetches KaTeX from the CDN during
-compilation). Pair with `--mathml` to avoid the penalty: >lua
+This inlines external resources into the HTML. With `--katex`, compile time
+increases by about 15s per save because pandoc fetches KaTeX during
+compilation. Pair with `--mathml` to avoid that penalty: >lua
 
     vim.g.preview = {
       github = { extra_args = { '--embed-resources', '--mathml' } },
     }
 <
+
+Diagram presets ~
+                                                    *preview-diagram-presets*
+
+  `plantuml` `.puml` → SVG.
+             Summary covers line-based parse errors and "no diagram found".
+
+  `mermaid`  `.mmd` → SVG via `mmdc`.
+             Summary only covers Mermaid parse errors, not generic CLI
+             failures.
+
+HTML presets ~
+                                                       *preview-html-presets*
+
+  `asciidoctor` `.adoc` → HTML with reload support.
+                Summary shows the first actionable asciidoctor error.
+
+  `quarto`      `.qmd` → HTML with `--embed-resources` and reload support.
+                Summary uses Quarto `ERROR:` lines.
 
 ==============================================================================
 COMMANDS                                                    *preview-commands*


### PR DESCRIPTION
## Problem

Closes #105.

`preview-presets` listed the built-in presets, but it did not explain the stable user-facing defaults for each preset family. The pandoc math guidance also sat as a detached subsection instead of living with the presets that use it.

## Solution

Reorganize the PRESETS section into navigable vimdoc subsections for preset notes, LaTeX presets, Pandoc presets, diagram presets, and HTML presets. Keep the scan-first table, move math guidance under the Pandoc section, add concise per-preset behavior notes, and point exact implementation details to `lua/preview/presets.lua`. Regenerated help tags and checked edited-line widths.
