### PR TITLE
feat: expose preview action mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,23 @@ luarocks install preview.nvim
 :help preview.nvim
 ```
 
+## Mappings
+
+preview.nvim defines no physical key mappings. It exposes stable normal-mode
+mapping targets for user configuration:
+
+| Mapping | Action |
+| --- | --- |
+| `<Plug>(preview-toggle)` | Toggle continuous preview |
+| `<Plug>(preview-compile)` | Compile once |
+| `<Plug>(preview-open)` | Open the latest generated output |
+| `<Plug>(preview-output)` | Show captured compiler output |
+| `<Plug>(preview-clean)` | Remove generated artifacts |
+
+```lua
+vim.keymap.set('n', '<leader>p', '<Plug>(preview-toggle)')
+```
+
 ## FAQ
 
 **Q: How do I define a custom provider?**

--- a/doc/preview.nvim.txt
+++ b/doc/preview.nvim.txt
@@ -317,6 +317,36 @@ COMMANDS                                                    *preview-commands*
     `status`     Echo compilation status (idle, compiling, watching).
 
 ==============================================================================
+MAPPINGS                                                    *preview-mappings*
+
+preview.nvim defines no physical key mappings. The following normal-mode
+|<Plug>| targets are available for user mappings:
+
+                                                      *<Plug>(preview-toggle)*
+<Plug>(preview-toggle)
+    Toggle auto-compile for the current buffer.
+
+                                                     *<Plug>(preview-compile)*
+<Plug>(preview-compile)
+    Compile the current buffer once.
+
+                                                        *<Plug>(preview-open)*
+<Plug>(preview-open)
+    Open the latest generated output without recompiling.
+
+                                                      *<Plug>(preview-output)*
+<Plug>(preview-output)
+    Open the stored raw compiler output in a scratch split.
+
+                                                       *<Plug>(preview-clean)*
+<Plug>(preview-clean)
+    Run the provider's clean command for the current buffer.
+
+Example: >lua
+    vim.keymap.set('n', '<leader>p', '<Plug>(preview-toggle)')
+<
+
+==============================================================================
 LUA API                                                          *preview-api*
 
 preview.toggle({bufnr?})                                    *preview.toggle()*

--- a/lua/preview/mappings.lua
+++ b/lua/preview/mappings.lua
@@ -1,0 +1,27 @@
+local M = {}
+
+local mappings = {
+  { 'toggle', 'Toggle document preview' },
+  { 'compile', 'Compile document preview once' },
+  { 'open', 'Open document preview output' },
+  { 'output', 'Show document preview compiler output' },
+  { 'clean', 'Clean document preview artifacts' },
+}
+
+local function callback(action)
+  return function()
+    require('preview')[action]()
+  end
+end
+
+function M.setup()
+  for _, mapping in ipairs(mappings) do
+    local action, desc = unpack(mapping)
+    vim.keymap.set('n', '<Plug>(preview-' .. action .. ')', callback(action), {
+      silent = true,
+      desc = desc,
+    })
+  end
+end
+
+return M

--- a/plugin/preview.lua
+++ b/plugin/preview.lua
@@ -4,6 +4,7 @@ end
 vim.g.loaded_preview = 1
 
 require('preview.commands').setup()
+require('preview.mappings').setup()
 
 pcall(function()
   require('preview.migration').warn_if_github_source()

--- a/spec/mappings_spec.lua
+++ b/spec/mappings_spec.lua
@@ -1,0 +1,66 @@
+local helpers = require('spec.helpers')
+
+local definitions = {
+  { 'toggle', 'Toggle document preview' },
+  { 'compile', 'Compile document preview once' },
+  { 'open', 'Open document preview output' },
+  { 'output', 'Show document preview compiler output' },
+  { 'clean', 'Clean document preview artifacts' },
+}
+
+local preview = require('preview')
+local originals = {}
+
+local function lhs(action)
+  return '<Plug>(preview-' .. action .. ')'
+end
+
+describe('mappings', function()
+  before_each(function()
+    helpers.reset_config()
+    for _, definition in ipairs(definitions) do
+      local action = definition[1]
+      originals[action] = preview[action]
+      pcall(vim.keymap.del, 'n', lhs(action))
+    end
+  end)
+
+  after_each(function()
+    for _, definition in ipairs(definitions) do
+      local action = definition[1]
+      preview[action] = originals[action]
+      pcall(vim.keymap.del, 'n', lhs(action))
+    end
+  end)
+
+  it('defines the public normal-mode mappings', function()
+    require('preview.mappings').setup()
+
+    for _, definition in ipairs(definitions) do
+      local action, desc = unpack(definition)
+      local mapping = vim.fn.maparg(lhs(action), 'n', false, true)
+      assert.are.equal(lhs(action), mapping.lhs)
+      assert.are.equal(desc, mapping.desc)
+      assert.are.equal(1, mapping.silent)
+      assert.is_function(mapping.callback)
+    end
+  end)
+
+  it('dispatches mappings through the public Lua API', function()
+    local called = {}
+    for _, definition in ipairs(definitions) do
+      local action = definition[1]
+      preview[action] = function()
+        called[action] = (called[action] or 0) + 1
+      end
+    end
+
+    require('preview.mappings').setup()
+
+    for _, definition in ipairs(definitions) do
+      local action = definition[1]
+      vim.fn.maparg(lhs(action), 'n', false, true).callback()
+      assert.are.equal(1, called[action])
+    end
+  end)
+end)


### PR DESCRIPTION
## Problem

preview.nvim exposes commands and Lua functions for its interactive actions, but users cannot bind those actions through stable `<Plug>` targets. Configurations must currently repeat command strings or callbacks and couple physical keys directly to the implementation.

## Solution

Expose normal-mode `<Plug>` mappings for toggling, one-shot compilation, opening generated output, inspecting compiler output, and cleaning artifacts. The mappings dispatch through the public Lua API, define descriptions without claiming physical keys, and are documented as the supported key-mapping interface.